### PR TITLE
Jag/errorhandling

### DIFF
--- a/src/flexalloc_mm.c
+++ b/src/flexalloc_mm.c
@@ -1195,7 +1195,7 @@ fla_acquire_slab(struct flexalloc *fs, const uint32_t obj_nlb,
   {
     // TODO : Define a proper error code for this.
     /* This error should not print anything as it is a valid state.  */
-    err = -1;
+    err = FLA_ERR_ALL_SLABS_USED;
     goto exit;
   }
 

--- a/src/flexalloc_shared.h
+++ b/src/flexalloc_shared.h
@@ -7,6 +7,7 @@ extern "C" {
 #endif
 
 #define FLA_ERR_ERROR 1001
+#define FLA_ERR_ALL_SLABS_USED 1002
 
 struct fla_pool;
 

--- a/src/flexalloc_shared.h
+++ b/src/flexalloc_shared.h
@@ -7,7 +7,7 @@ extern "C" {
 #endif
 
 #define FLA_ERR_ERROR 1001
-#define FLA_ERR_ALL_SLABS_USED 1002
+#define FLA_ERR_ALL_SLABS_USED 2001
 
 struct fla_pool;
 

--- a/src/flexalloc_util.h
+++ b/src/flexalloc_util.h
@@ -40,7 +40,7 @@ static inline int
 fla_err_fl(const int condition, const char * message, const char * f,
            const int l )
 {
-  if(condition)
+  if(condition && condition < 1001)
   {
     FLA_ERR_PRINTF(" %s(%d) %s\n", f, l, message);
   }

--- a/src/flexalloc_util.h
+++ b/src/flexalloc_util.h
@@ -40,7 +40,7 @@ static inline int
 fla_err_fl(const int condition, const char * message, const char * f,
            const int l )
 {
-  if(condition && condition < 1001)
+  if(condition && condition < 2001)
   {
     FLA_ERR_PRINTF(" %s(%d) %s\n", f, l, message);
   }


### PR DESCRIPTION
Automatically propagate errors based on their number.
This avoids getting a bunch of error messages on stderr when you hit a valid execution path with an error that is caught and addressed.