### PR TITLE
flexalloc: Add opts struct to open call

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -26,9 +26,10 @@ xnvme_deps = [thread_dep, uuid_dep, numa_dep, aio_dep, rt_dep, xnvme_dep]
 flexalloc_util_files = ['src/flexalloc_util.c']
 flexalloc_introspect = ['src/flexalloc_introspection.c']
 xnvme_env_files = ['src/flexalloc_xnvme_env.c', 'src/flexalloc_xnvme_env.h']
+flexalloc_znd_files = ['src/flexalloc_znd.c', 'src/flexalloc_znd.h']
 flexalloc_common =  ['src/flexalloc.c', 'src/flexalloc_mm.c', 'src/flexalloc_hash.c', 'src/flexalloc_bits.c',
   'src/flexalloc_freelist.c', 'src/flexalloc_ll.c', 'src/flexalloc_ll.h', 'src/flexalloc_slabcache.c',
-  xnvme_env_files, flexalloc_util_files]
+  xnvme_env_files, flexalloc_util_files, flexalloc_znd_files]
 
 libflexalloc_headers = ['src/libflexalloc.h', 'src/flexalloc_shared.h']
 libflexalloc_files = ['src/libflexalloc.c', flexalloc_common]

--- a/meson.build
+++ b/meson.build
@@ -87,6 +87,9 @@ core_tests = {
   'rt_object_read_write'
   : {'sources': 'tests/flexalloc_rt_object_read_write.c',
     'suite' : 'core'},
+  'rt_strp_object_read_write'
+  : {'sources': 'tests/flexalloc_rt_strp_object_read_write.c',
+    'suite' : 'core'},
   'rt_object_unaligned_write'
   : {'sources': 'tests/flexalloc_rt_object_unaligned_write.c',
     'suite' : 'core'},

--- a/src/flexalloc.h
+++ b/src/flexalloc.h
@@ -11,9 +11,18 @@
 #define __FLEXALLOC_H_
 #include <stdint.h>
 #include <libxnvme.h>
+#include <sys/queue.h>
 #include "flexalloc_shared.h"
 #include "flexalloc_freelist.h"
 #include "flexalloc_hash.h"
+
+struct fla_zs_entry
+{
+  int zone_number;
+  TAILQ_ENTRY(fla_zs_entry) entries;
+};
+
+TAILQ_HEAD(zs_thead, fla_zs_entry);
 
 /// flexalloc device handle
 struct fla_dev
@@ -115,6 +124,8 @@ struct flexalloc
   struct fla_super *super;
   struct fla_pools pools;
   struct fla_slabs slabs;
+  struct zs_thead zs_thead;
+  uint32_t zs_size;
 };
 
 struct fla_pool

--- a/src/flexalloc.h
+++ b/src/flexalloc.h
@@ -11,7 +11,6 @@
 #define __FLEXALLOC_H_
 #include <stdint.h>
 #include <libxnvme.h>
-#include <sys/queue.h>
 #include "flexalloc_shared.h"
 #include "flexalloc_freelist.h"
 #include "flexalloc_hash.h"

--- a/src/flexalloc_freelist.c
+++ b/src/flexalloc_freelist.c
@@ -92,9 +92,8 @@ fla_flist_load(void *data)
 
 // find and take a spot in the freelist, returning its index
 int
-fla_flist_entry_alloc(freelist_t flist)
+fla_flist_entry_alloc(freelist_t flist, uint32_t elems)
 {
-  uint32_t elems = FLA_FREELIST_U32_ELEMS(*flist);
   uint32_t *elem;
   uint32_t wndx = 0;
 
@@ -112,6 +111,28 @@ fla_flist_entry_alloc(freelist_t flist)
     return i * sizeof(uint32_t) * 8 + ntz(wndx);
   }
   return -1;
+}
+
+int
+fla_flist_entries_alloc(freelist_t flist, unsigned int num)
+{
+  uint32_t elems = FLA_FREELIST_U32_ELEMS(*flist);
+  uint32_t alloc_count = 0;
+  int alloc_ret;
+
+  if (num == 1)
+    return fla_flist_entry_alloc(flist, elems);
+
+  while (alloc_count != num)
+  {
+    alloc_ret = fla_flist_entry_alloc(flist, elems);
+    if (alloc_ret != -1)
+      alloc_count++;
+    else
+      return alloc_ret;
+  }
+
+  return alloc_ret;
 }
 
 // release a taken element from freelist

--- a/src/flexalloc_freelist.h
+++ b/src/flexalloc_freelist.h
@@ -120,12 +120,13 @@ fla_flist_load(void *data);
  * case -1 is returned.
  *
  * @param flist freelist handle
+ * @param unsigned int num of entries to allocate
  * @return On success, a value between 0 and `len` (the freelist length)
  * indicating which element of the freelist has been reserved. On error,
  * -1, in which case no allocation was made.
  */
 int
-fla_flist_entry_alloc(freelist_t flist);
+fla_flist_entries_alloc(freelist_t flist, unsigned int num);
 
 /**
  * Free an entry from the freelist.

--- a/src/flexalloc_inspect.c
+++ b/src/flexalloc_inspect.c
@@ -205,6 +205,7 @@ main(int argc, char **argv)
   struct flexalloc *fs;
   char *dev_uri = NULL;
   int err = 0;
+  struct fla_open_opts open_opts = {0};
 
   for (int i = 0; i < num_opts; i++)
   {
@@ -231,10 +232,10 @@ main(int argc, char **argv)
     goto exit;
   }
 
-  dev_uri = argv[optind++];
+  open_opts.dev_uri = argv[optind++];
 
   fprintf(stdout, "opening flexalloc system on %s...\n", dev_uri);
-  err = fla_open(dev_uri, &fs);
+  err = fla_open(&open_opts, &fs);
   if (err)
   {
     fprintf(stderr, "failed to open device '%s'\n", dev_uri);

--- a/src/flexalloc_mkfs.c
+++ b/src/flexalloc_mkfs.c
@@ -42,6 +42,11 @@ static struct cli_option options[] =
     .arg_ex = NULL
   },
   {
+    .base = {"md_dev", optional_argument, NULL, 'm'},
+    .description = "MD device to use\n",
+    .arg_ex = "/path/to/md_device"
+  },
+  {
     .base = {NULL, 0, NULL, 0}
   }
 };
@@ -71,7 +76,7 @@ fla_mkfs_parse_args(int argc, char ** argv, struct fla_mkfs_p * p)
     memcpy(long_options+i, &options[i].base, sizeof(struct option));
   }
 
-  while ((c = getopt_long(argc, argv, "vhs:p:", long_options, &opt_idx)) != -1)
+  while ((c = getopt_long(argc, argv, "vhs:p:m:", long_options, &opt_idx)) != -1)
   {
     switch (c)
     {
@@ -99,6 +104,9 @@ fla_mkfs_parse_args(int argc, char ** argv, struct fla_mkfs_p * p)
         err = -1;
       }
       p->npools = (int)arg_long;
+      break;
+    case 'm':
+      p->md_dev_uri = optarg;
       break;
     default:
       break;
@@ -155,6 +163,7 @@ main(int argc, char ** argv)
   struct fla_mkfs_p mkfs_params =
   {
     .dev_uri = NULL,
+    .md_dev_uri = NULL,
     .slab_nlb = 0,
     .verbose = 0,
   };
@@ -173,6 +182,9 @@ main(int argc, char ** argv)
   fprintf(stderr, "  dev_uri: %s\n", mkfs_params.dev_uri);
   fprintf(stderr, "  slab_nlb: %"PRIu32"\n", mkfs_params.slab_nlb);
   fprintf(stderr, "  verbose: %"PRIu8"\n", mkfs_params.verbose);
+  if (mkfs_params.md_dev_uri)
+    fprintf(stderr, "  md_dev_uri: %s\n", mkfs_params.md_dev_uri);
+
   fla_mkfs(&mkfs_params);
 
 exit:

--- a/src/flexalloc_mm.c
+++ b/src/flexalloc_mm.c
@@ -1616,6 +1616,12 @@ fla_fs_nzsect(struct flexalloc const *fs)
   return fs->geo.nzsect;
 }
 
+bool
+fla_fs_zns(struct flexalloc const *fs)
+{
+  return fs->geo.type == XNVME_GEO_ZONED;
+}
+
 int
 fla_open_common(const char *dev_uri, struct flexalloc *fs)
 {

--- a/src/flexalloc_mm.c
+++ b/src/flexalloc_mm.c
@@ -1487,6 +1487,15 @@ fla_fs_lb_nbytes(struct flexalloc const * const fs)
   return fs->dev.lb_nbytes;
 }
 
+uint32_t
+fla_pool_obj_nlb(struct flexalloc const * const fs, struct fla_pool const *pool_handle)
+{
+  struct fla_pool_entry * pool_entry;
+
+  pool_entry = &fs->pools.entries[pool_handle->ndx];
+  return pool_entry->obj_nlb;
+}
+
 int
 fla_open_common(const char *dev_uri, struct flexalloc *fs)
 {

--- a/src/flexalloc_mm.c
+++ b/src/flexalloc_mm.c
@@ -1496,6 +1496,12 @@ fla_pool_obj_nlb(struct flexalloc const * const fs, struct fla_pool const *pool_
   return pool_entry->obj_nlb;
 }
 
+uint64_t
+fla_fs_nzsect(struct flexalloc const *fs)
+{
+  return fs->geo.nzsect;
+}
+
 int
 fla_open_common(const char *dev_uri, struct flexalloc *fs)
 {

--- a/src/flexalloc_mm.h
+++ b/src/flexalloc_mm.h
@@ -252,5 +252,9 @@ fla_slab_id(const struct fla_slab_header * slab, const struct flexalloc * fs,
 int
 fla_format_slab(struct flexalloc *fs, struct fla_slab_header * slab, uint32_t obj_nlb);
 
+uint64_t
+fla_object_slba(struct flexalloc const * fs, struct fla_object const * obj,
+                const struct fla_pool * pool_handle);
+
 #endif // __FLEXALLOC_MM_H_
 

--- a/src/flexalloc_mm.h
+++ b/src/flexalloc_mm.h
@@ -19,7 +19,7 @@
 #define FLA_STATE_OPEN 1U
 
 #define FLA_NAME_SIZE 128
-#define FLA_NAME_SIZE_POOL 120
+#define FLA_NAME_SIZE_POOL 112
 
 // -------------------------------
 #define FLA_ROOT_OBJ_NONE UINT64_MAX
@@ -95,6 +95,14 @@ struct fla_pool_entry
   ///
   /// Pools can have any valid flexalloc object set as a root object
   uint64_t root_obj_hndl;
+  /// Num of objects to stripe across
+  ///
+  /// Pools may optionally hand out striped objects
+  uint32_t strp_num;
+  /// Size of each stripe chunk
+  ///
+  /// Must be set if we ste strp_num
+  uint32_t strp_sz;
   /// Human-readable cache identifier
   ///
   /// The cache name is primarily used for debugging statistics

--- a/src/flexalloc_mm.h
+++ b/src/flexalloc_mm.h
@@ -137,7 +137,7 @@ struct fla_super
  * @return The logical block offset of the slab.
  */
 uint64_t
-fla_geo_slab_lb_off(struct fla_geo const *geo, uint32_t slab_id);
+fla_geo_slab_lb_off(struct flexalloc const *fs, uint32_t slab_id);
 
 uint64_t
 fla_geo_slab_sgmt_lb_off(struct fla_geo const *geo);

--- a/src/flexalloc_shared.h
+++ b/src/flexalloc_shared.h
@@ -9,6 +9,7 @@ extern "C" {
 #define FLA_ERR_ERROR 1001
 
 struct fla_pool;
+struct flexalloc;
 
 /// flexalloc object handle
 ///
@@ -28,6 +29,15 @@ typedef enum
   ROOT_OBJ_SET_FORCE = 1 << 0,
   ROOT_OBJ_SET_CLEAR = 1 << 1
 } fla_root_object_set_action;
+
+/**
+ * @brief Return the number of bytes in a block in fs
+ *
+ * @param fs flexalloc system handl
+ * @return number of bytes in a block
+ */
+int32_t
+fla_fs_lb_nbytes(struct flexalloc const * const fs);
 
 #ifdef __cplusplus
 }

--- a/src/flexalloc_shared.h
+++ b/src/flexalloc_shared.h
@@ -1,6 +1,7 @@
 #ifndef FLEXALLOC_SHARED_H_
 #define FLEXALLOC_SHARED_H_
 #include <stdint.h>
+#include <libxnvme.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -10,6 +11,18 @@ extern "C" {
 
 struct fla_pool;
 struct flexalloc;
+
+/// flexalloc open options
+///
+/// Minimally the dev_uri needs to be set
+/// If the md_dev is set than flexalloc md will be stored on this device
+/// The xnvme open options are optionally set at open time as well
+struct fla_open_opts
+{
+  const char *dev_uri;
+  const char *md_dev_uri;
+  struct xnvme_opts opts;
+};
 
 /// flexalloc object handle
 ///

--- a/src/flexalloc_slabcache.c
+++ b/src/flexalloc_slabcache.c
@@ -213,7 +213,7 @@ fla_slab_cache_elem_drop(struct fla_slab_flist_cache *cache, uint32_t slab_id)
 
 int
 fla_slab_cache_obj_alloc(struct fla_slab_flist_cache *cache, uint32_t slab_id,
-                         struct fla_object *obj_id)
+                         struct fla_object *obj_id, uint32_t num_objs)
 {
   struct fla_slab_flist_cache_elem *e = &cache->_head[slab_id];
   int err, entry_ndx;
@@ -221,7 +221,7 @@ fla_slab_cache_obj_alloc(struct fla_slab_flist_cache *cache, uint32_t slab_id,
   if (e->state == FLA_SLAB_CACHE_ELEM_STALE)
     return FLA_SLAB_CACHE_INVALID_STATE;
 
-  entry_ndx = fla_flist_entry_alloc(e->freelist);
+  entry_ndx = fla_flist_entries_alloc(e->freelist, num_objs);
   if ((err = FLA_ERR(entry_ndx < 0,
                      "fla_flist_entry_alloc() - failed to allocate an object in freelist")))
     return err;

--- a/src/flexalloc_slabcache.c
+++ b/src/flexalloc_slabcache.c
@@ -33,8 +33,7 @@ cache_entry_lb_slba(struct fla_slab_flist_cache const * cache, const uint32_t sl
   if (cache->_fs->dev.md_dev)
     return fla_geo_slabs_lb_off(&cache->_fs->geo) + slab_id;
   else
-    return fla_geo_slab_lb_off(&cache->_fs->geo, slab_id) + cache->_fs->super->slab_nlb
-           - flist_nlb;
+    return fla_geo_slab_lb_off(cache->_fs, slab_id) + cache->_fs->super->slab_nlb - flist_nlb;
 }
 
 int

--- a/src/flexalloc_slabcache.h
+++ b/src/flexalloc_slabcache.h
@@ -174,6 +174,7 @@ fla_slab_cache_elem_drop(struct fla_slab_flist_cache *cache, uint32_t slab_id);
  * @param cache slab freelist cache
  * @param slab_id id of the slab to reserve an entry from
  * @param obj_id pointer to a object id struct - to be populated if operation is successful
+ * @parm strp_num Number of objects to stripe across
  *
  * @return On success 0, with obj_id set to uniquely identify the reserved object.
  * Non-zero return values indicate an error. FLA_SLAB_CACHE_INVALID_STATE means
@@ -182,7 +183,7 @@ fla_slab_cache_elem_drop(struct fla_slab_flist_cache *cache, uint32_t slab_id);
  */
 int
 fla_slab_cache_obj_alloc(struct fla_slab_flist_cache *cache, uint32_t slab_id,
-                         struct fla_object *obj_id);
+                         struct fla_object *obj_id, uint32_t strp_num);
 
 /**
  * Release object entry reservation.

--- a/src/flexalloc_xnvme_env.h
+++ b/src/flexalloc_xnvme_env.h
@@ -10,6 +10,13 @@
 #include <libxnvme.h>
 #include <libxnvme_lba.h>
 
+struct fla_sync_strp_params
+{
+  uint32_t strp_num;
+  uint32_t strp_sz;
+  uint64_t obj_len;
+};
+
 /**
  * @brief Synchronous sequential write defined by lbs
  *
@@ -22,6 +29,10 @@
 int
 fla_xne_sync_seq_w_naddrs(struct xnvme_dev * dev, const uint64_t slba, const uint64_t naddrs,
                           void const * buf);
+
+int
+fla_xne_sync_strp_seq_x(struct xnvme_dev *dev, const uint64_t offset, uint64_t nbytes,
+                        void const *buf, struct fla_sync_strp_params *sp, bool write);
 
 int
 /**

--- a/src/flexalloc_xnvme_env.h
+++ b/src/flexalloc_xnvme_env.h
@@ -127,7 +127,14 @@ void
 fla_xne_dev_close(struct xnvme_dev *dev);
 
 int
-fla_xne_dev_znd_reset(struct xnvme_dev *dev, uint64_t slba, bool all);
+fla_xne_dev_znd_send_mgmt(struct xnvme_dev *dev, uint64_t slba,
+                          enum xnvme_spec_znd_cmd_mgmt_send_action act, bool);
+
+uint32_t
+fla_xne_dev_get_znd_mar(struct xnvme_dev *dev);
+
+uint32_t
+fla_xne_dev_get_znd_mor(struct xnvme_dev *dev);
 
 int
 fla_xne_dev_mkfs_prepare(struct xnvme_dev *dev, char *md_dev_uri, struct xnvme_dev **md_dev);

--- a/src/flexalloc_znd.c
+++ b/src/flexalloc_znd.c
@@ -1,0 +1,106 @@
+// Copyright (C) 2022 Adam Manzanares <a.manzanares@samsung.com>
+#include "flexalloc_znd.h"
+#include "flexalloc_xnvme_env.h"
+#include "flexalloc_mm.h"
+#include "flexalloc_util.h"
+
+// Full zones are implicitly placed into the closed state so no need to manage anymore
+void
+fla_znd_zone_full(struct flexalloc *fs, uint32_t zone)
+{
+  struct fla_zs_entry *z_entry;
+
+  TAILQ_FOREACH(z_entry, &fs->zs_thead, entries)
+  {
+    if (z_entry->zone_number == zone)
+      break;
+  }
+
+  // We should probably warn here
+  if (!z_entry)
+    return;
+
+  TAILQ_REMOVE(&fs->zs_thead, z_entry, entries);
+  fs->zs_size--;
+}
+
+void
+fla_znd_manage_zones_cleanup(struct flexalloc *fs)
+{
+  struct fla_zs_entry *z_entry;
+
+  while ((z_entry = TAILQ_FIRST(&fs->zs_thead)))
+  {
+    TAILQ_REMOVE(&fs->zs_thead, z_entry, entries);
+    free(z_entry);
+  }
+}
+
+void
+fla_znd_manage_zones(struct flexalloc *fs, uint32_t zone)
+{
+
+  struct fla_zs_entry *z_entry;
+  uint64_t zlba;
+  int ret;
+
+  TAILQ_FOREACH(z_entry, &fs->zs_thead, entries)
+  {
+    if (z_entry->zone_number == zone)
+      break;
+  }
+
+  if (z_entry)
+  {
+    // We found the entry so remove and reinsert at head
+    TAILQ_REMOVE(&fs->zs_thead, z_entry, entries);
+    TAILQ_INSERT_HEAD(&fs->zs_thead, z_entry, entries);
+    return;
+  }
+
+  // We are under the number of zones limit
+  if (fs->zs_size < fla_xne_dev_get_znd_mor(fs->dev.dev))
+  {
+    z_entry = malloc(sizeof(struct fla_zs_entry));
+    assert(z_entry);
+    z_entry->zone_number = zone;
+    TAILQ_INSERT_HEAD(&fs->zs_thead, z_entry, entries);
+    fs->zs_size++;
+  }
+  else // We have to close a zone
+  {
+    z_entry = TAILQ_LAST(&fs->zs_thead, zs_thead);
+    assert(z_entry);
+    zlba = z_entry->zone_number * fs->geo.nzsect;
+    ret = fla_xne_dev_znd_send_mgmt(fs->dev.dev, zlba, XNVME_SPEC_ZND_CMD_MGMT_SEND_CLOSE, false);
+    if (ret)
+      FLA_ERR_PRINTF("Error trying to close zone at:%lu\n", zlba);
+
+    z_entry->zone_number = zone;
+    TAILQ_REMOVE(&fs->zs_thead, z_entry, entries);
+    TAILQ_INSERT_HEAD(&fs->zs_thead, z_entry, entries);
+  }
+}
+
+bool
+fla_object_seal(struct flexalloc *fs, struct fla_pool const *pool_handle, struct fla_object *obj)
+{
+
+  uint64_t obj_slba = fla_object_slba(fs, obj, pool_handle);
+  uint32_t obj_zn = obj_slba / fs->geo.nzsect;
+  struct fla_pool_entry *pool_entry = &fs->pools.entries[pool_handle->ndx];
+  uint32_t strps = pool_entry->strp_num;
+
+  for (uint32_t strp = 0; strp < strps; strp++)
+  {
+    int err = fla_xne_dev_znd_send_mgmt(fs->dev.dev, obj_slba + (fs->geo.nzsect * strp),
+                                        XNVME_SPEC_ZND_CMD_MGMT_SEND_FINISH, false);
+    if (FLA_ERR(err, "fla_xne_dev_znd_send_mgmt_finish()"))
+      return false;
+  }
+
+  // Update me for striping
+  fla_znd_zone_full(fs, obj_zn);
+  return true;
+}
+

--- a/src/flexalloc_znd.h
+++ b/src/flexalloc_znd.h
@@ -1,0 +1,24 @@
+/**
+ * flexalloc disk structures.
+ *
+ * Copyright (C) 2022 Adam Manzanares <a.manzanares@samsung.com>
+ *
+ * @file flexalloc_znd.h
+ */
+#ifndef __FLEXALLOC_ZND_H_
+#define __FLEXALLOC_ZND_H_
+#include <sys/queue.h>
+#include <stdint.h>
+#include "src/flexalloc.h"
+
+
+void
+fla_znd_zone_full(struct flexalloc *fs, uint32_t zone);
+
+void
+fla_znd_manage_zones_cleanup(struct flexalloc *fs);
+
+void
+fla_znd_manage_zones(struct flexalloc *fs, uint32_t zone);
+
+#endif // __FLEXALLOC_ZND_H

--- a/src/libflexalloc.h
+++ b/src/libflexalloc.h
@@ -275,6 +275,15 @@ int
 fla_pool_get_root_object(struct flexalloc const * const fs,
                          struct fla_pool const * pool,
                          struct fla_object *object);
+/**
+ * @brief Return size of objects in terms of nlb with the pool
+ *
+ * @param fs !FS system handle
+ * @param pool_handle !FS pool handle to associate obj with
+ * @return Zero on failure, obj nlb for the pool otherwise
+ */
+uint32_t
+fla_pool_obj_nlb(struct flexalloc const *const fs, struct fla_pool const *pool_handle);
 
 #ifdef __cplusplus
 }

--- a/src/libflexalloc.h
+++ b/src/libflexalloc.h
@@ -22,26 +22,14 @@ struct flexalloc;
 
 /**
  * Open flexalloc system
- * @param dev_uri path to device node, e.g. "/dev/nvme0"
+ * @param opts pointer to initialized fla open opts struct
  * @param flexalloc pointer to flexalloc system handle, if successful, otherwise uninitialized.
  *
  * @return On success 0 and *fs pointing to a flexalloc system handle. On error, non-zero
  * and *fs being uninitialized.
  */
 int
-fla_open(const char *dev_uri, struct flexalloc **fs);
-
-/**
- * Open flexalloc with MD on a separate device
- * @param dev_uri path to device node that does not have MD, e.g. "/dev/nvme0n1"
- * @parm md_dev_uri path to device node where MD will be stored, e.g "/dev/nvme0n2"
- * @param flexalloc pointer to flexalloc system handle, if successful, otherwise uninitialized.
- *
- * @return On success 0 and *fs pointing to a flexalloc system handle. On error, non-zero
- * and *fs being uninitialized.
- */
-int
-fla_md_open(const char *dev_uri, const char *md_dev_uri, struct flexalloc **fs);
+fla_open(struct fla_open_opts *opts, struct flexalloc **fs);
 
 /**
  * Close flexalloc system.

--- a/src/libflexalloc.h
+++ b/src/libflexalloc.h
@@ -270,8 +270,8 @@ fla_pool_get_root_object(struct flexalloc const * const fs,
 /**
  * @brief Return size of objects in terms of nlb with the pool
  *
- * @param fs !FS system handle
- * @param pool_handle !FS pool handle to associate obj with
+ * @param fs flexalloc system handle
+ * @param pool_handle flexalloc pool handle to associate obj with
  * @return Zero on failure, obj nlb for the pool otherwise
  */
 uint32_t
@@ -280,13 +280,25 @@ fla_pool_obj_nlb(struct flexalloc const *const fs, struct fla_pool const *pool_h
 /**
  * @brief Return the number of sectors in a zone device zone
  *
- * @param fs !FS system handle
+ * @param fs flexalloc system handle
  * @return number of sectors in each zone
  */
 uint64_t
 fla_fs_nzsect(struct flexalloc const * const fs);
 
 bool fla_fs_zns(struct flexalloc const *const fs);
+
+/**
+ *
+ * @brief Seal a flexalloc object
+ *
+ * @param fs flexalloc system handle
+ * @param pool_handle flexalloc pool handle associated with obj
+ * @param obj flexalloc object handle to seal
+ * @return bool indicating object was successfully sealed
+ */
+bool fla_object_seal(struct flexalloc *fs, struct fla_pool const *pool_handle,
+                     struct fla_object *obj);
 
 #ifdef __cplusplus
 }

--- a/src/libflexalloc.h
+++ b/src/libflexalloc.h
@@ -285,6 +285,15 @@ fla_pool_get_root_object(struct flexalloc const * const fs,
 uint32_t
 fla_pool_obj_nlb(struct flexalloc const *const fs, struct fla_pool const *pool_handle);
 
+/**
+ * @brief Return the number of sectors in a zone device zone
+ *
+ * @param fs !FS system handle
+ * @return number of sectors in each zone
+ */
+uint64_t
+fla_fs_nzsect(struct flexalloc const * const fs);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/libflexalloc.h
+++ b/src/libflexalloc.h
@@ -220,7 +220,7 @@ fla_object_read(struct flexalloc const * fs, struct fla_pool const * pool,
  * @return Zero on success. non zero otherwise
  */
 int
-fla_object_write(struct flexalloc const * fs, struct fla_pool const * pool,
+fla_object_write(struct flexalloc * fs, struct fla_pool const * pool,
                  struct fla_object const * object, void const * buf, size_t offset, size_t len);
 
 /**
@@ -235,19 +235,10 @@ fla_object_write(struct flexalloc const * fs, struct fla_pool const * pool,
  * @return Zero on success. non zero otherwise
  */
 int
-fla_object_unaligned_write(struct flexalloc const * fs,
+fla_object_unaligned_write(struct flexalloc * fs,
                            struct fla_pool const * pool,
                            struct fla_object const * object, void const * buf, size_t offset,
                            size_t len);
-
-/**
- * @brief Return the number of bytes in a block in fs
- *
- * @param fs flexalloc system handl
- * @return number of bytes in a block
- */
-int32_t
-fla_fs_lb_nbytes(struct flexalloc const * const fs);
 
 /**
  * @brief Associate object with pool

--- a/src/libflexalloc.h
+++ b/src/libflexalloc.h
@@ -11,6 +11,7 @@
 #define __LIBFLEXALLOC_H_
 #include <stdlib.h>
 #include <stdint.h>
+#include <stdbool.h>
 #include "flexalloc_shared.h"
 
 #ifdef __cplusplus
@@ -284,6 +285,8 @@ fla_pool_obj_nlb(struct flexalloc const *const fs, struct fla_pool const *pool_h
  */
 uint64_t
 fla_fs_nzsect(struct flexalloc const * const fs);
+
+bool fla_fs_zns(struct flexalloc const *const fs);
 
 #ifdef __cplusplus
 }

--- a/src/libflexalloc.h
+++ b/src/libflexalloc.h
@@ -286,7 +286,8 @@ fla_pool_obj_nlb(struct flexalloc const *const fs, struct fla_pool const *pool_h
 uint64_t
 fla_fs_nzsect(struct flexalloc const * const fs);
 
-bool fla_fs_zns(struct flexalloc const *const fs);
+bool
+fla_fs_zns(struct flexalloc const *const fs);
 
 /**
  *
@@ -297,8 +298,22 @@ bool fla_fs_zns(struct flexalloc const *const fs);
  * @param obj flexalloc object handle to seal
  * @return bool indicating object was successfully sealed
  */
-bool fla_object_seal(struct flexalloc *fs, struct fla_pool const *pool_handle,
-                     struct fla_object *obj);
+bool
+fla_object_seal(struct flexalloc *fs, struct fla_pool const *pool_handle, struct fla_object *obj);
+
+/**
+ *
+ * @brief Indicate that a pool should hand out striped objects
+ *
+ * @param fs flexalloc system handle
+ * @param pool_handle flexalloc pool handle to set as being striped
+ * @param strp_num number of objects to stripe across
+ * @param strp_sz size of each stripe chunk in bytes
+ * @return int indicating if pool striping parameters were applied
+ */
+int
+fla_pool_set_strp(struct flexalloc *fs, struct fla_pool const *pool_handle, uint32_t strp_num,
+                  uint32_t strp_sz);
 
 #ifdef __cplusplus
 }

--- a/tests/flexalloc_rt_multi_pool_read_write.c
+++ b/tests/flexalloc_rt_multi_pool_read_write.c
@@ -31,6 +31,7 @@ main(int argc, char **argv)
   struct fla_object obj[NUM_POOLS] = {0};
   struct test_vals t_val = {0};
   struct fla_ut_dev tdev = {0};
+  struct fla_open_opts open_opts = {0};
 
   err = fla_ut_dev_init(t_val.blk_num, &tdev);
   if (FLA_ERR(err, "fla_ut_dev_init()"))
@@ -82,8 +83,9 @@ main(int argc, char **argv)
   if(FLA_ERR(err, "fla_close()"))
     goto free_write_buffer;
 
-  err = fla_md_open(tdev._dev_uri, tdev._md_dev_uri, &fs);
-
+  open_opts.dev_uri = tdev._dev_uri;
+  open_opts.md_dev_uri = tdev._md_dev_uri;
+  err = fla_open(&open_opts, &fs);
   if(FLA_ERR(err, "fla_open()"))
     goto free_write_buffer;
 

--- a/tests/flexalloc_rt_object_read_write.c
+++ b/tests/flexalloc_rt_object_read_write.c
@@ -24,6 +24,7 @@ main(int argc, char **argv)
   struct flexalloc *fs = NULL;
   struct fla_pool *pool_handle;
   struct fla_object obj;
+  struct fla_open_opts open_opts = {0};
   struct test_vals test_vals
       = {.blk_num = 40000, .slab_nlb = 4000, .npools = 1, .obj_nlb = 2};
 
@@ -73,11 +74,9 @@ main(int argc, char **argv)
   if(FLA_ERR(err, "fla_close()"))
     goto free_write_buffer;
 
-  if (!dev._md_dev_uri)
-    err = fla_open(dev._dev_uri, &fs);
-  else
-    err = fla_md_open(dev._dev_uri, dev._md_dev_uri, &fs);
-
+  open_opts.dev_uri = dev._dev_uri;
+  open_opts.md_dev_uri = dev._md_dev_uri;
+  err = fla_open(&open_opts, &fs);
   if(FLA_ERR(err, "fla_open()"))
     goto free_write_buffer;
 

--- a/tests/flexalloc_rt_pool.c
+++ b/tests/flexalloc_rt_pool.c
@@ -83,6 +83,7 @@ main(int argc, char **argv)
   struct fla_ut_dev dev;
   struct flexalloc *fs = NULL;
   struct fla_pool * handle;
+  struct fla_open_opts open_opts = {0};
   int err = 0, ret;
 
   err = fla_ut_dev_init(40000, &dev);
@@ -136,15 +137,9 @@ main(int argc, char **argv)
   if (FLA_ERR(err, "fla_close()"))
     goto teardown_ut_fs;
 
-  if (dev._md_dev_uri)
-  {
-    err = fla_md_open(dev._dev_uri, dev._md_dev_uri, &fs);
-  }
-  else
-  {
-    err = fla_open(dev._dev_uri, &fs);
-  }
-
+  open_opts.dev_uri = dev._dev_uri;
+  open_opts.md_dev_uri = dev._md_dev_uri;
+  err = fla_open(&open_opts, &fs);
   if (FLA_ERR(err, "fla_open() - failed to re-open device"))
     goto teardown_ut_fs;
 
@@ -179,17 +174,10 @@ main(int argc, char **argv)
     goto teardown_ut_fs;
 
   // We need to reopen the device to verify pools have been destroyed
-  if (dev._is_zns)
-  {
-    err = fla_md_open(dev._dev_uri, dev._md_dev_uri, &fs);
-  }
-  else
-  {
-    err = fla_open(dev._dev_uri, &fs);
-  }
-
+  err = fla_open(&open_opts, &fs);
   if (FLA_ERR(err, "fla_open() - failed to re-open device"))
     goto teardown_ut_fs;
+
   for (unsigned int i = 0; i < pools_len; i++)
   {
     err = fla_pool_open(fs, pools[i].name, &handle) == 0;

--- a/tests/flexalloc_rt_strp_object_read_write.c
+++ b/tests/flexalloc_rt_strp_object_read_write.c
@@ -1,0 +1,157 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "src/libflexalloc.h"
+#include "src/flexalloc.h"
+#include "src/flexalloc_util.h"
+#include "tests/flexalloc_tests_common.h"
+
+struct test_vals
+{
+  uint64_t blk_num;
+  uint32_t npools;
+  uint32_t slab_nlb;
+  uint32_t obj_nlb;
+};
+
+int
+main(int argc, char **argv)
+{
+  int err, ret;
+  char * pool_handle_name, * write_msg, *write_buf, *read_buf;
+  size_t write_msg_len, buf_len;
+  struct fla_ut_dev dev;
+  struct flexalloc *fs = NULL;
+  struct fla_pool *pool_handle;
+  struct fla_object obj;
+  struct test_vals test_vals
+      = {.blk_num = 40000, .slab_nlb = 4000, .npools = 1, .obj_nlb = 2};
+
+  pool_handle_name = "mypool";
+  write_msg = "hello, world";
+  write_msg_len = strlen(write_msg);
+
+  err = fla_ut_dev_init(test_vals.blk_num, &dev);
+  if (FLA_ERR(err, "fla_ut_dev_init()"))
+    goto exit;
+
+  if (dev._is_zns)
+  {
+    test_vals.slab_nlb = dev.nsect_zn;
+    test_vals.obj_nlb = dev.nsect_zn;
+  }
+
+  err = fla_ut_fs_create(test_vals.slab_nlb, test_vals.npools, &dev, &fs);
+  if (FLA_ERR(err, "fla_ut_fs_create()"))
+  {
+    goto teardown_ut_dev;
+  }
+
+  buf_len = FLA_CEIL_DIV(write_msg_len, dev.lb_nbytes) * dev.lb_nbytes * 2;
+
+  err = fla_pool_create(fs, pool_handle_name, strlen(pool_handle_name), test_vals.obj_nlb,
+                        &pool_handle);
+  if(FLA_ERR(err, "fla_pool_create()"))
+    goto teardown_ut_fs;
+
+  err = fla_pool_set_strp(fs, pool_handle, 2, dev.lb_nbytes);
+  if (FLA_ERR(err, "fla_pool_set_strp()"))
+    goto release_pool;
+
+  err = fla_object_create(fs, pool_handle, &obj);
+  if(FLA_ERR(err, "fla_object_create()"))
+    goto release_pool;
+
+  write_buf = fla_buf_alloc(fs, buf_len);
+  if((err = FLA_ERR(!write_buf, "fla_buf_alloc()")))
+    goto release_object;
+
+  memcpy(write_buf, write_msg, write_msg_len);
+  write_buf[write_msg_len] = '\0';
+
+  err = fla_object_write(fs, pool_handle, &obj, write_buf, 0, buf_len);
+  if(FLA_ERR(err, "fla_object_write()"))
+    goto free_write_buffer;
+
+  err = fla_close(fs);
+  if(FLA_ERR(err, "fla_close()"))
+    goto free_write_buffer;
+
+  if (!dev._md_dev_uri)
+    err = fla_open(dev._dev_uri, &fs);
+  else
+    err = fla_md_open(dev._dev_uri, dev._md_dev_uri, &fs);
+
+  if(FLA_ERR(err, "fla_open()"))
+    goto free_write_buffer;
+
+  fla_pool_close(fs, pool_handle);
+  err = fla_pool_open(fs, pool_handle_name, &pool_handle);
+  if(FLA_ERR(err, "fla_pool_open()"))
+    goto free_write_buffer;
+
+  err = fla_object_open(fs, pool_handle, &obj);
+  if(FLA_ERR(err, "fla_object_open()"))
+    goto free_write_buffer;
+
+  read_buf = fla_buf_alloc(fs, buf_len);
+  if((err = FLA_ERR(!read_buf, "fla_buf_alloc()")))
+    goto free_write_buffer;
+
+  err = fla_object_read(fs, pool_handle, &obj, read_buf, 0, buf_len);
+  if(FLA_ERR(err, "fla_obj_read()"))
+    goto free_read_buffer;
+
+  // compare that the string (and terminating NULL) was read back
+  err = memcmp(write_buf,  read_buf, buf_len + 1);
+  if(FLA_ERR(err, "memcmp() - failed to read back the written value"))
+    goto free_write_buffer;
+
+  // Free the object, which should reset a zone
+  ret = fla_object_destroy(fs, pool_handle, &obj);
+  if(FLA_ERR(ret, "fla_object_destroy()"))
+    err = ret;
+
+  // Allocate a new object
+  err = fla_object_create(fs, pool_handle, &obj);
+  if(FLA_ERR(err, "fla_object_create()"))
+    goto release_pool;
+
+  // Will fail on zns without object reset
+  err = fla_object_write(fs, pool_handle, &obj, write_buf, 0, buf_len);
+  if(FLA_ERR(err, "fla_object_write()"))
+    goto free_write_buffer;
+
+free_read_buffer:
+  fla_buf_free(fs, read_buf);
+
+free_write_buffer:
+  fla_buf_free(fs, write_buf);
+
+release_object:
+  ret = fla_object_destroy(fs, pool_handle, &obj);
+  if(FLA_ERR(ret, "fla_object_destroy()"))
+    err = ret;
+
+release_pool:
+  ret = fla_pool_destroy(fs, pool_handle);
+  if(FLA_ERR(ret, "fla_pool_destroy()"))
+    err = ret;
+
+teardown_ut_fs:
+  ret = fla_ut_fs_teardown(fs);
+  if (FLA_ERR(ret, "fla_ut_fs_teardown()"))
+  {
+    err = ret;
+  }
+
+teardown_ut_dev:
+  ret = fla_ut_dev_teardown(&dev);
+  if (FLA_ERR(ret, "fla_ut_dev_teardown()"))
+  {
+    err = ret;
+  }
+
+exit:
+  return err;
+}

--- a/tests/flexalloc_rt_strp_object_read_write.c
+++ b/tests/flexalloc_rt_strp_object_read_write.c
@@ -24,6 +24,7 @@ main(int argc, char **argv)
   struct flexalloc *fs = NULL;
   struct fla_pool *pool_handle;
   struct fla_object obj;
+  struct fla_open_opts open_opts = {0};
   struct test_vals test_vals
       = {.blk_num = 40000, .slab_nlb = 4000, .npools = 1, .obj_nlb = 2};
 
@@ -77,11 +78,9 @@ main(int argc, char **argv)
   if(FLA_ERR(err, "fla_close()"))
     goto free_write_buffer;
 
-  if (!dev._md_dev_uri)
-    err = fla_open(dev._dev_uri, &fs);
-  else
-    err = fla_md_open(dev._dev_uri, dev._md_dev_uri, &fs);
-
+  open_opts.dev_uri = dev._dev_uri;
+  open_opts.md_dev_uri = dev._md_dev_uri;
+  err = fla_open(&open_opts, &fs);
   if(FLA_ERR(err, "fla_open()"))
     goto free_write_buffer;
 

--- a/tests/flexalloc_tests_common.h
+++ b/tests/flexalloc_tests_common.h
@@ -129,10 +129,6 @@ int
 fla_ut_fs_teardown(struct flexalloc *fs);
 
 int
-fla_ut_dev_fs_create(char *uri, char *md_uri, uint32_t slab_nlb, uint32_t npools,
-                     struct flexalloc **fs);
-
-int
 fla_ut_temp_file_create(const int size, char * created_name);
 
 int

--- a/tests/flexalloc_ut_freelist.c
+++ b/tests/flexalloc_ut_freelist.c
@@ -172,7 +172,7 @@ test_flist_reset(uint32_t len)
 
   for (unsigned int i = 0; i < len; i++)
   {
-    if ((err = FLA_ASSERTF(fla_flist_entry_alloc(f2) == i,
+    if ((err = FLA_ASSERTF(fla_flist_entries_alloc(f2, 1) == i,
                            "expected allocation %u to succeed", i)))
       goto exit;
   }
@@ -217,9 +217,9 @@ test_flist_37_alloc_free_max()
 
   // allocate all spaces
   for (unsigned int i = 0; i < 37; i++)
-    err |= FLA_ASSERTF(fla_flist_entry_alloc(f) == i, "alloc failed for i=%u", i);
+    err |= FLA_ASSERTF(fla_flist_entries_alloc(f, 1) == i, "alloc failed for i=%u", i);
 
-  FLA_ASSERT(fla_flist_entry_alloc(f) == -1, "expected failure to allocate");
+  FLA_ASSERT(fla_flist_entries_alloc(f, 1) == -1, "expected failure to allocate");
 
   FLA_ASSERT(fla_flist_entry_free(f, 0) == 0, "expected free to work");
   FLA_ASSERT(fla_flist_entry_free(f, 1) == 0, "expected free to work");
@@ -253,9 +253,9 @@ test_alloc_free_deep()
 
   // allocate all spaces
   for (unsigned int i = 0; i < 8; i++)
-    err |= FLA_ASSERTF(fla_flist_entry_alloc(f) == i, "alloc failed for i=%u", i);
+    err |= FLA_ASSERTF(fla_flist_entries_alloc(f, 1) == i, "alloc failed for i=%u", i);
 
-  err |= FLA_ASSERT(fla_flist_entry_alloc(f) == -1, "expected failure to allocate");
+  err |= FLA_ASSERT(fla_flist_entries_alloc(f, 1) == -1, "expected failure to allocate");
   err |= FLA_ASSERT(*FLIST_ENTRY(f, 0) == 0, "expected all entries taken");
 
   err |= FLA_ASSERT(fla_flist_entry_free(f, 0) == 0, "expected free to work");
@@ -272,10 +272,10 @@ test_alloc_free_deep()
                      0));
 
   // re-alloc the free entries
-  err |= FLA_ASSERT(fla_flist_entry_alloc(f) == 0, "unexpected alloc");
-  err |= FLA_ASSERT(fla_flist_entry_alloc(f) == 1, "unexpected alloc");
-  err |= FLA_ASSERT(fla_flist_entry_alloc(f) == 5, "unexpected alloc");
-  err |= FLA_ASSERT(fla_flist_entry_alloc(f) == 7, "unexpected alloc");
+  err |= FLA_ASSERT(fla_flist_entries_alloc(f, 1) == 0, "unexpected alloc");
+  err |= FLA_ASSERT(fla_flist_entries_alloc(f, 1) == 1, "unexpected alloc");
+  err |= FLA_ASSERT(fla_flist_entries_alloc(f, 1) == 5, "unexpected alloc");
+  err |= FLA_ASSERT(fla_flist_entries_alloc(f, 1) == 7, "unexpected alloc");
 
 exit:
   if (f) free(f);


### PR DESCRIPTION
We have two open calls in the api, one for a single device and one for single
device + a metadata device. This makes the code a bit ugly so this commit
introduces a parameter struct to the open call.

Signed-off-by: Adam Manzanares <a.manzanares@samsung.com>