### PR TITLE
flexalloc: Add opts struct to open call

### DIFF
--- a/fio-ioengine/flexalloc.c
+++ b/fio-ioengine/flexalloc.c
@@ -233,7 +233,8 @@ static void fio_flexalloc_cleanup(struct thread_data *td)
  * FS open and pool creation are protected by a mutex even if they target
  * different devices.
  */
-static int fio_flexalloc_open_direct(const char *dev_uri, const char *md_dev_uri, int thread_number, struct flexalloc **fs)
+static int fio_flexalloc_open_direct(const char *dev_uri, const char *md_dev_uri,
+    int thread_number, struct flexalloc **fs)
 {
 	struct thread_data *td;
 	int i;
@@ -267,13 +268,11 @@ static int fio_flexalloc_open_direct(const char *dev_uri, const char *md_dev_uri
 		}
 	}
 
-	if (md_dev_uri) {
-		dprint(FD_IO, "flexalloc: opening file system on %s with metadata on %s\n", dev_uri, md_dev_uri);
-		return fla_md_open(dev_uri, md_dev_uri, fs);
-	} else {
-		dprint(FD_IO, "flexalloc: opening file system on %s\n", dev_uri);
-		return fla_open(dev_uri, fs);
-	}
+	struct fla_open_opts open_opts = {0};
+	open_opts.dev_uri = dev_uri;
+	if(md_dev_uri)
+		open_opts.md_dev_uri = md_dev_uri;
+	return fla_open(&open_opts, fs);
 }
 
 static int fio_flexalloc_open_daemon(struct flexalloc_data *data, struct flexalloc_options *opts)

--- a/pyflexalloc/flexalloc/flexalloc.pxd
+++ b/pyflexalloc/flexalloc/flexalloc.pxd
@@ -88,7 +88,7 @@ cdef extern from "flexalloc.h" nogil:
     cdef struct fla_open_opts:
       char *dev_uri
       char *md_dev_uri
-      xnvme_opts opts
+      xnvme_opts *opts
 
 
 cdef class FlexAlloc:

--- a/pyflexalloc/flexalloc/flexalloc.pxd
+++ b/pyflexalloc/flexalloc/flexalloc.pxd
@@ -3,6 +3,7 @@ Copyright (C) 2021 Jesper Devantier <j.devantier@samsung.com>
 """
 from libc.stdint cimport uint64_t, uint32_t
 from flexalloc.xnvme_env cimport xnvme_dev
+from flexalloc.xnvme_env cimport xnvme_opts
 from flexalloc.hash cimport fla_htbl
 from flexalloc.freelist cimport freelist_t
 from flexalloc.slabcache cimport fla_slab_flist_cache_elem
@@ -83,6 +84,11 @@ cdef extern from "flexalloc.h" nogil:
     cdef struct fla_pool:
         uint64_t h2
         uint32_t ndx
+
+    cdef struct fla_open_opts:
+      char *dev_uri
+      char *md_dev_uri
+      xnvme_opts opts
 
 
 cdef class FlexAlloc:

--- a/pyflexalloc/flexalloc/libflexalloc.pxd
+++ b/pyflexalloc/flexalloc/libflexalloc.pxd
@@ -37,8 +37,7 @@ cdef extern from "libflexalloc.h" nogil:
       ROOT_OBJ_SET_FORCE = 1 << 0,
       ROOT_OBJ_SET_CLEAR = 1 << 1,
 
-    int fla_open(char *dev_uri, flexalloc ** fs)
-    int fla_md_open(char *dev_uri, char *md_dev_uri, flexalloc ** fs)
+    int fla_open(fla_open_opts *opts, flexalloc **fs)
     # wrapper for this call is implemented directly on the FlexAlloc type
     # int fla_close(flexalloc *fs)
     int fla_sync(flexalloc *fs)

--- a/pyflexalloc/flexalloc/libflexalloc.pyx
+++ b/pyflexalloc/flexalloc/libflexalloc.pyx
@@ -13,12 +13,13 @@ def open(dev_uri: str, md_dev_uri: str = None) -> FlexAlloc:
     cdef char *c_mdev_str
     if (md_dev_uri is not None):
         py_dev_mstr = md_dev_uri.encode("ascii")
+        c_mdev_str = py_dev_mstr
     else:
-        py_dev_mstr = "".encode("ascii")
+        c_mdev_str = NULL
 
-    c_mdev_str = py_dev_mstr
     oopts.dev_uri = c_dev_str
     oopts.md_dev_uri = c_mdev_str
+    oopts.opts = NULL;
     if fla_open(&oopts, &data):
         raise MemoryError("failed to open FlexAlloc system")
 

--- a/pyflexalloc/flexalloc/libflexalloc.pyx
+++ b/pyflexalloc/flexalloc/libflexalloc.pyx
@@ -5,30 +5,25 @@ from pathlib import Path
 from typing import Union
 
 
-def open(dev_uri: str) -> FlexAlloc:
-    py_str = dev_uri.encode("ascii")
-    cdef char *c_str = py_str
+def open(dev_uri: str, md_dev_uri: str = None) -> FlexAlloc:
+    py_dev_str = dev_uri.encode("ascii")
+    cdef char *c_dev_str = py_dev_str
     cdef flexalloc *data
-    if fla_open(c_str, &data):
+    cdef fla_open_opts oopts
+    cdef char *c_mdev_str
+    if (md_dev_uri is not None):
+        py_dev_mstr = md_dev_uri.encode("ascii")
+    else:
+        py_dev_mstr = "".encode("ascii")
+
+    c_mdev_str = py_dev_mstr
+    oopts.dev_uri = c_dev_str
+    oopts.md_dev_uri = c_mdev_str
+    if fla_open(&oopts, &data):
         raise MemoryError("failed to open FlexAlloc system")
 
     cdef FlexAlloc fs = FlexAlloc.from_ptr(data)
     return fs
-
-
-def md_open(dev_uri: str, md_dev_uri: str) -> FlexAlloc:
-    dev_pystr = dev_uri.encode("ascii")
-    cdef char *dev_cstr = dev_pystr
-    md_dev_pystr = md_dev_uri.encode("ascii")
-    cdef char *md_dev_cstr = md_dev_pystr
-
-    cdef flexalloc *data
-    if fla_md_open(dev_cstr, md_dev_cstr, &data):
-        raise MemoryError("failed to open FlexAlloc system")
-
-    cdef FlexAlloc fs = FlexAlloc.from_ptr(data)
-    return fs
-
 
 def daemon_open(socket: Union[str, Path]) -> FlexAllocDaemonClient:
     return FlexAllocDaemonClient.open(socket)

--- a/src/flexalloc_daemon.c
+++ b/src/flexalloc_daemon.c
@@ -126,6 +126,7 @@ main(int argc, char **argv)
   struct fla_daemon daemon;
   int const n_opts = sizeof(options)/sizeof(struct cli_option);
   struct option long_options[n_opts];
+  struct fla_open_opts fla_oopts = {0};
 
   for (int i=0; i<n_opts; i++)
   {
@@ -152,7 +153,8 @@ main(int argc, char **argv)
     fla_daemon_usage();
     err = 2;
     if (!socket_path)
-      fprintf(stderr, "missing socket argument - must specify where to create the UNIX socket mediating access to FlexAlloc system\n");
+      fprintf(stderr,
+              "missing socket argument - must specify where to create the UNIX socket mediating access to FlexAlloc system\n");
     if (!device)
       fprintf(stderr, "missing device argument - must specify which device holds the FlexAlloc system\n");
     goto exit;
@@ -167,8 +169,9 @@ main(int argc, char **argv)
   daemon.identity.type = FLA_SYS_FLEXALLOC_TYPE;
   daemon.identity.version = FLA_SYS_FLEXALLOC_V1;
 
-  err = fla_open_common(device, daemon.flexalloc);
-  if (FLA_ERR(err, "fla_open_common()"))
+  fla_oopts.dev_uri = device;
+  err = fla_open(&fla_oopts, &daemon.flexalloc);
+  if (FLA_ERR(err, "fla_open()"))
     goto exit;
 
   fprintf(stderr, "daemon ready for connections...\n");

--- a/src/flexalloc_inspect.c
+++ b/src/flexalloc_inspect.c
@@ -205,6 +205,7 @@ main(int argc, char **argv)
   struct flexalloc *fs;
   char *dev_uri = NULL;
   int err = 0;
+  struct fla_open_opts open_opts = {0};
 
   for (int i = 0; i < num_opts; i++)
   {
@@ -231,10 +232,10 @@ main(int argc, char **argv)
     goto exit;
   }
 
-  dev_uri = argv[optind++];
+  open_opts.dev_uri = argv[optind++];
 
   fprintf(stdout, "opening flexalloc system on %s...\n", dev_uri);
-  err = fla_open(dev_uri, &fs);
+  err = fla_open(&open_opts, &fs);
   if (err)
   {
     fprintf(stderr, "failed to open device '%s'\n", dev_uri);

--- a/src/flexalloc_mm.c
+++ b/src/flexalloc_mm.c
@@ -1634,7 +1634,7 @@ fla_open(struct fla_open_opts *opts, struct flexalloc **fs)
     goto exit;
   }
 
-  err = fla_xne_dev_open(opts->dev_uri, &opts->opts, &dev);
+  err = fla_xne_dev_open(opts->dev_uri, opts->opts, &dev);
   if (FLA_ERR(err, "fla_xne_dev_open()"))
     goto free_fs;
 

--- a/src/flexalloc_shared.h
+++ b/src/flexalloc_shared.h
@@ -1,6 +1,7 @@
 #ifndef FLEXALLOC_SHARED_H_
 #define FLEXALLOC_SHARED_H_
 #include <stdint.h>
+#include <libxnvme.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -13,6 +14,18 @@ struct flexalloc;
 
 struct fla_pool;
 struct flexalloc;
+
+/// flexalloc open options
+///
+/// Minimally the dev_uri needs to be set
+/// If the md_dev is set than flexalloc md will be stored on this device
+/// The xnvme open options are optionally set at open time as well
+struct fla_open_opts
+{
+  const char *dev_uri;
+  const char *md_dev_uri;
+  struct xnvme_opts opts;
+};
 
 /// flexalloc object handle
 ///

--- a/src/flexalloc_shared.h
+++ b/src/flexalloc_shared.h
@@ -24,7 +24,7 @@ struct fla_open_opts
 {
   const char *dev_uri;
   const char *md_dev_uri;
-  struct xnvme_opts opts;
+  struct xnvme_opts *opts;
 };
 
 /// flexalloc object handle

--- a/src/libflexalloc.h
+++ b/src/libflexalloc.h
@@ -22,26 +22,14 @@ struct flexalloc;
 
 /**
  * Open flexalloc system
- * @param dev_uri path to device node, e.g. "/dev/nvme0"
+ * @param opts pointer to initialized fla open opts struct
  * @param flexalloc pointer to flexalloc system handle, if successful, otherwise uninitialized.
  *
  * @return On success 0 and *fs pointing to a flexalloc system handle. On error, non-zero
  * and *fs being uninitialized.
  */
 int
-fla_open(const char *dev_uri, struct flexalloc **fs);
-
-/**
- * Open flexalloc with MD on a separate device
- * @param dev_uri path to device node that does not have MD, e.g. "/dev/nvme0n1"
- * @parm md_dev_uri path to device node where MD will be stored, e.g "/dev/nvme0n2"
- * @param flexalloc pointer to flexalloc system handle, if successful, otherwise uninitialized.
- *
- * @return On success 0 and *fs pointing to a flexalloc system handle. On error, non-zero
- * and *fs being uninitialized.
- */
-int
-fla_md_open(const char *dev_uri, const char *md_dev_uri, struct flexalloc **fs);
+fla_open(struct fla_open_opts *opts, struct flexalloc **fs);
 
 /**
  * Close flexalloc system.

--- a/tests/flexalloc_rt_multi_pool_read_write.c
+++ b/tests/flexalloc_rt_multi_pool_read_write.c
@@ -33,6 +33,7 @@ main(int argc, char **argv)
   struct fla_ut_dev tdev = {0};
   struct fla_open_opts open_opts = {0};
 
+  open_opts.opts = NULL;
   err = fla_ut_dev_init(t_val.blk_num, &tdev);
   if (FLA_ERR(err, "fla_ut_dev_init()"))
     goto exit;

--- a/tests/flexalloc_rt_multi_pool_read_write.c
+++ b/tests/flexalloc_rt_multi_pool_read_write.c
@@ -31,6 +31,7 @@ main(int argc, char **argv)
   struct fla_object obj[NUM_POOLS] = {0};
   struct test_vals t_val = {0};
   struct fla_ut_dev tdev = {0};
+  struct fla_open_opts open_opts = {0};
 
   err = fla_ut_dev_init(t_val.blk_num, &tdev);
   if (FLA_ERR(err, "fla_ut_dev_init()"))
@@ -82,8 +83,9 @@ main(int argc, char **argv)
   if(FLA_ERR(err, "fla_close()"))
     goto free_write_buffer;
 
-  err = fla_md_open(tdev._dev_uri, tdev._md_dev_uri, &fs);
-
+  open_opts.dev_uri = tdev._dev_uri;
+  open_opts.md_dev_uri = tdev._md_dev_uri;
+  err = fla_open(&open_opts, &fs);
   if(FLA_ERR(err, "fla_open()"))
     goto free_write_buffer;
 

--- a/tests/flexalloc_rt_object_read_write.c
+++ b/tests/flexalloc_rt_object_read_write.c
@@ -24,6 +24,7 @@ main(int argc, char **argv)
   struct flexalloc *fs = NULL;
   struct fla_pool *pool_handle;
   struct fla_object obj;
+  struct fla_open_opts open_opts = {0};
   struct test_vals test_vals
       = {.blk_num = 40000, .slab_nlb = 4000, .npools = 1, .obj_nlb = 2};
 
@@ -73,11 +74,9 @@ main(int argc, char **argv)
   if(FLA_ERR(err, "fla_close()"))
     goto free_write_buffer;
 
-  if (!dev._md_dev_uri)
-    err = fla_open(dev._dev_uri, &fs);
-  else
-    err = fla_md_open(dev._dev_uri, dev._md_dev_uri, &fs);
-
+  open_opts.dev_uri = dev._dev_uri;
+  open_opts.md_dev_uri = dev._md_dev_uri;
+  err = fla_open(&open_opts, &fs);
   if(FLA_ERR(err, "fla_open()"))
     goto free_write_buffer;
 

--- a/tests/flexalloc_rt_pool.c
+++ b/tests/flexalloc_rt_pool.c
@@ -83,6 +83,7 @@ main(int argc, char **argv)
   struct fla_ut_dev dev;
   struct flexalloc *fs = NULL;
   struct fla_pool * handle;
+  struct fla_open_opts open_opts = {0};
   int err = 0, ret;
 
   err = fla_ut_dev_init(40000, &dev);
@@ -136,15 +137,9 @@ main(int argc, char **argv)
   if (FLA_ERR(err, "fla_close()"))
     goto teardown_ut_fs;
 
-  if (dev._md_dev_uri)
-  {
-    err = fla_md_open(dev._dev_uri, dev._md_dev_uri, &fs);
-  }
-  else
-  {
-    err = fla_open(dev._dev_uri, &fs);
-  }
-
+  open_opts.dev_uri = dev._dev_uri;
+  open_opts.md_dev_uri = dev._md_dev_uri;
+  err = fla_open(&open_opts, &fs);
   if (FLA_ERR(err, "fla_open() - failed to re-open device"))
     goto teardown_ut_fs;
 
@@ -179,17 +174,10 @@ main(int argc, char **argv)
     goto teardown_ut_fs;
 
   // We need to reopen the device to verify pools have been destroyed
-  if (dev._is_zns)
-  {
-    err = fla_md_open(dev._dev_uri, dev._md_dev_uri, &fs);
-  }
-  else
-  {
-    err = fla_open(dev._dev_uri, &fs);
-  }
-
+  err = fla_open(&open_opts, &fs);
   if (FLA_ERR(err, "fla_open() - failed to re-open device"))
     goto teardown_ut_fs;
+
   for (unsigned int i = 0; i < pools_len; i++)
   {
     err = fla_pool_open(fs, pools[i].name, &handle) == 0;

--- a/tests/flexalloc_rt_strp_object_read_write.c
+++ b/tests/flexalloc_rt_strp_object_read_write.c
@@ -24,6 +24,7 @@ main(int argc, char **argv)
   struct flexalloc *fs = NULL;
   struct fla_pool *pool_handle;
   struct fla_object obj;
+  struct fla_open_opts open_opts = {0};
   struct test_vals test_vals
       = {.blk_num = 40000, .slab_nlb = 4000, .npools = 1, .obj_nlb = 2};
 
@@ -77,11 +78,9 @@ main(int argc, char **argv)
   if(FLA_ERR(err, "fla_close()"))
     goto free_write_buffer;
 
-  if (!dev._md_dev_uri)
-    err = fla_open(dev._dev_uri, &fs);
-  else
-    err = fla_md_open(dev._dev_uri, dev._md_dev_uri, &fs);
-
+  open_opts.dev_uri = dev._dev_uri;
+  open_opts.md_dev_uri = dev._md_dev_uri;
+  err = fla_open(&open_opts, &fs);
   if(FLA_ERR(err, "fla_open()"))
     goto free_write_buffer;
 

--- a/tests/flexalloc_tests_common.h
+++ b/tests/flexalloc_tests_common.h
@@ -129,10 +129,6 @@ int
 fla_ut_fs_teardown(struct flexalloc *fs);
 
 int
-fla_ut_dev_fs_create(char *uri, char *md_uri, uint32_t slab_nlb, uint32_t npools,
-                     struct flexalloc **fs);
-
-int
 fla_ut_temp_file_create(const int size, char * created_name);
 
 int


### PR DESCRIPTION
We have two open calls in the api, one for a single device and one for single
device + a metadata device. This makes the code a bit ugly so this commit
introduces a parameter struct to the open call.

Signed-off-by: Adam Manzanares <a.manzanares@samsung.com>

This is related to #12 