### PR TITLE
compile fio ioengine if fio src dir is provided

### DIFF
--- a/fio-ioengine/meson.build
+++ b/fio-ioengine/meson.build
@@ -1,0 +1,41 @@
+cc = meson.get_compiler('c')
+rt_dep = cc.find_library('rt', required: true)
+pconf = import('pkgconfig')
+fs = import('fs')
+
+fio_dir = get_option('fio_source_dir')
+if not fs.exists(fio_dir)
+    error('fio source directory does not exist!')
+elif not fs.is_dir(fio_dir)
+    error('fio_source_dir does not point to a directory!')
+elif not fs.exists(fio_dir / 'config-host.h')
+    error('no `config-host.h` file in fio_source_directory, run `./configure` in fio dir and re-try!')
+endif
+
+flexallocfioe = shared_module(
+  meson.project_name() + '-fio-engine',
+  ['flexalloc.c'],
+  override_options: ['c_std=gnu11'],
+  include_directories: [
+      libflexalloc_header_dirs,
+      include_directories(fio_dir),
+      ],
+  dependencies: [rt_dep],
+  link_with: library.get_static_lib(),
+  install: true,
+  c_args: [
+    '-D_GNU_SOURCE',
+    '-include', 'config-host.h'
+  ]
+)
+
+pconf.generate(
+  libraries: [ flexallocfioe ],
+  version: meson.project_version(),
+  variables: [
+    'datadir=' + get_option('prefix') / get_option('datadir') / meson.project_name()
+  ],
+  name: 'flexalloc-fioe',
+  filebase: meson.project_name() + '-fio-engine',
+  description : 'flexalloc fio I/O engine'
+)

--- a/meson.build
+++ b/meson.build
@@ -23,6 +23,7 @@ xnvme_deps = [thread_dep, uuid_dep, numa_dep, aio_dep, rt_dep, xnvme_dep]
 
 
 ### Files ###
+libflexalloc_header_dirs = include_directories('./src')
 flexalloc_util_files = ['src/flexalloc_util.c']
 flexalloc_introspect = ['src/flexalloc_introspection.c']
 xnvme_env_files = ['src/flexalloc_xnvme_env.c', 'src/flexalloc_xnvme_env.h']
@@ -31,9 +32,7 @@ flexalloc_common =  ['src/flexalloc.c', 'src/flexalloc_mm.c', 'src/flexalloc_has
   'src/flexalloc_freelist.c', 'src/flexalloc_ll.c', 'src/flexalloc_ll.h', 'src/flexalloc_slabcache.c',
   xnvme_env_files, flexalloc_util_files, flexalloc_znd_files]
 
-flexalloc_daemon_headers = ['src/flexalloc_daemon_base.h']
 flexalloc_daemon_files = ['src/flexalloc_daemon_base.c']
-libflexalloc_headers = ['src/libflexalloc.h', 'src/flexalloc_shared.h', flexalloc_daemon_headers]
 libflexalloc_files = ['src/libflexalloc.c', flexalloc_common]
 
 ### Executables ###
@@ -47,7 +46,20 @@ executable('flexalloc_client', ['src/flexalloc_test_client.c', flexalloc_common,
 ### Libraries ###
 library = both_libraries('flexalloc', [libflexalloc_files, flexalloc_daemon_files],
                          dependencies: xnvme_deps, install : true)
-install_headers(libflexalloc_headers)
+
+foreach header_file: [
+  'libflexalloc.h',
+  'flexalloc_shared.h',
+  'flexalloc_daemon_base.h',
+  ]
+  install_headers('src' / header_file)
+endforeach
+
+if get_option('fio_source_dir') != ''
+  subdir('fio-ioengine')
+else
+  warning('fio engine build: NO\n\t `meson --reconfigure -Dfio_source_dir=<fio source dir> <build-dir>` to enable')
+endif
 
 ### Tests ###
 flexalloc_testing = ['tests/flexalloc_tests_common.c', 'tests/flexalloc_tests_common.h']

--- a/meson.build
+++ b/meson.build
@@ -58,7 +58,7 @@ endforeach
 if get_option('fio_source_dir') != ''
   subdir('fio-ioengine')
 else
-  warning('fio engine build: NO\n\t `meson --reconfigure -Dfio_source_dir=<fio source dir> <build-dir>` to enable')
+  message('***  fio engine build: NO  ****\n\t `meson --reconfigure -Dfio_source_dir=<fio source dir> <build-dir>` to enable')
 endif
 
 ### Tests ###

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,2 +1,3 @@
 option('FLEXALLOC_VERBOSITY', type : 'integer', min : 0, max : 1, value : 0)
 option('FLEXALLOC_XNVME_IGNORE_MDTS', type : 'boolean', value : false)
+option('fio_source_dir', type: 'string', value: '')


### PR DESCRIPTION
Set `fio_source_dir` to the path of a valid, and configured, fio
source code directory. If set, the flexalloc fio ioengine is built
against this fio engine.