### PR TITLE
Jwd/fio engine multitenant

### DIFF
--- a/fio-ioengine/flexalloc.c
+++ b/fio-ioengine/flexalloc.c
@@ -7,7 +7,8 @@
  */
 #include <stdlib.h>
 #include <assert.h>
-#include <libflexalloc.h>
+#include "libflexalloc.h"
+#include "flexalloc_daemon_base.h"
 
 #include <fio.h>
 #include <optgroup.h>


### PR DESCRIPTION
Expand fio io engine to support opening the FlexAlloc system in multi-tenant (daemon) mode.

## Testing
1. compile project with fio io engine (see `meson configure`, ensure `fio_source_dir` is set and points to a copy of the fio source code)
2. Start the daemon (I use a script listed below to format the device, print options and start the daemon)
3. Run a suitable fio test (see fio section for scripts)

Using the scripts defined below, testing can be done like so:
#### multi-tenant/daemon test
First start the daemon:
```
$ ./daemon_start
```

```
$ USE_GDB=0 USE_DEV_RESET=0 FIO_FILE=test.daemon.fio ./fio_test
```

#### direct test (open device)
```
$ USE_GDB=0 USE_DEV_RESET=1 FIO_FILE=test.direct.fio ./fio_test
```


## Scripts
### daemon script
`daemon_start.sh`:
```bash
#!/usr/bin/env bash
FLEXALLOC_SOCKET="${FLEXALLOC_SOCKET:-/tmp/flexalloc.socket}"
FLEXALLOC_SLAB_NLB="${FLEXALLOC_SLAB_NLB:-3276800}"
FLEXALLOC_NPOOLS="${FLEXALLOC_NPOOLS:-70}"
FLEXALLOC_DEV="${FLEXALLOC_DEV:-/dev/nvme0n1}"


echo "FLEXALLOC_SOCKET:		${FLEXALLOC_SOCKET}"
echo "FLEXALLOC_SLAB_NLB:	${FLEXALLOC_SLAB_NLB}"
echo "FLEXALLOC_NPOOLS:		${FLEXALLOC_NPOOLS}"
echo "FLEXALLOC_DEV:		${FLEXALLOC_DEV}"

set -ex
rm -rf "${FLEXALLOC_SOCKET}" || echo ""

meson build || meson --reconfigure build
meson compile -C build
build/mkfs.flexalloc --slba-nlb=${FLEXALLOC_SLAB_NLB} -p ${FLEXALLOC_NPOOLS} ${FLEXALLOC_DEV}
build/flexalloc_daemon -d ${FLEXALLOC_DEV} -s ${FLEXALLOC_SOCKET}
```
### FIO
```bash
#!/usr/bin/env bash
FLEXALLOC_SOCKET="${FLEXALLOC_SOCKET:-/tmp/flexalloc.socket}"
FLEXALLOC_SLAB_NLB="${FLEXALLOC_SLAB_NLB:-3276800}"
FLEXALLOC_NPOOLS="${FLEXALLOC_NPOOLS:-70}"
FLEXALLOC_DEV="${FLEXALLOC_DEV:-/dev/nvme0n1}"

USE_GDB="${USE_GDB:-0}"
USE_DIRECT="${USE_DEV_RESET:-0}"
FIO_FILE="${FIO_FILE:-test.direct.fio}"


echo "FLEXALLOC_SOCKET:		${FLEXALLOC_SOCKET}"
echo "FLEXALLOC_SLAB_NLB:	${FLEXALLOC_SLAB_NLB}"
echo "FLEXALLOC_NPOOLS:		${FLEXALLOC_NPOOLS}"
echo "FLEXALLOC_DEV:		${FLEXALLOC_DEV}"

echo "USE_GDB:			${USE_GDB}"
echo "USE_DEV_RESET:		${USE_DEV_RESET}"
echo "FIO FILE:			${FIO_FILE}"

echo "**NOTE** if USE_DEV_RESET=1 the device will be formatted"

set -ex

if [ "${USE_DIRECT}" == "1" ]; then
	# meson build || meson --reconfigure build
	meson compile -C build
	build/mkfs.flexalloc --slba-nlb=${FLEXALLOC_SLAB_NLB} -p ${FLEXALLOC_NPOOLS} ${FLEXALLOC_DEV}
fi

if [ "${USE_GDB}" == "1" ]; then
	CMD_PREFIX="gdb --args"
else
	CMD_PREFIX=""
fi

## TODO: change '/root/fio/fio' to the path of your fio binary
$CMD_PREFIX /root/fio/fio --ioengine=external:./build/fio-ioengine/libflexalloc-fio-engine.so "${FIO_FILE}"
```

`test.direct.fio`:
```
[global]
ioengine=flexalloc
direct=1
dev_uri=/dev/nvme0n1
rw=randwrite
thread=1
 
[job1]
filesize=10M
nrfiles=100
poolname=testpool1
 
[job2]
filesize=100M
nrfiles=3
poolname=testpool2
```

`test.daemon.fio`:
```
[global]
ioengine=flexalloc
direct=1
daemon_uri=/tmp/flexalloc.socket
rw=randwrite
thread=1
 
[job1]
filesize=10M
nrfiles=100
poolname=testpool1
 
[job2]
filesize=100M
nrfiles=3
poolname=testpool2
```