### PR TITLE
Jag/smaller than strp nobjs reads

### DIFF
--- a/src/flexalloc_mm.h
+++ b/src/flexalloc_mm.h
@@ -95,14 +95,17 @@ struct fla_pool_entry
   ///
   /// Pools can have any valid flexalloc object set as a root object
   uint64_t root_obj_hndl;
+
   /// Num of objects to stripe across
   ///
   /// Pools may optionally hand out striped objects
-  uint32_t strp_num;
+
+  uint32_t strp_nobjs;
   /// Size of each stripe chunk
   ///
-  /// Must be set if we ste strp_num
-  uint32_t strp_sz;
+  /// Must be set if we ste strp_nobjs
+
+  uint32_t strp_nbytes;
   /// Human-readable cache identifier
   ///
   /// The cache name is primarily used for debugging statistics

--- a/src/flexalloc_slabcache.h
+++ b/src/flexalloc_slabcache.h
@@ -174,7 +174,7 @@ fla_slab_cache_elem_drop(struct fla_slab_flist_cache *cache, uint32_t slab_id);
  * @param cache slab freelist cache
  * @param slab_id id of the slab to reserve an entry from
  * @param obj_id pointer to a object id struct - to be populated if operation is successful
- * @parm strp_num Number of objects to stripe across
+ * @parm strp_nobjs Number of objects to stripe across
  *
  * @return On success 0, with obj_id set to uniquely identify the reserved object.
  * Non-zero return values indicate an error. FLA_SLAB_CACHE_INVALID_STATE means
@@ -183,7 +183,7 @@ fla_slab_cache_elem_drop(struct fla_slab_flist_cache *cache, uint32_t slab_id);
  */
 int
 fla_slab_cache_obj_alloc(struct fla_slab_flist_cache *cache, uint32_t slab_id,
-                         struct fla_object *obj_id, uint32_t strp_num);
+                         struct fla_object *obj_id, uint32_t strp_nobjs);
 
 /**
  * Release object entry reservation.

--- a/src/flexalloc_xnvme_env.c
+++ b/src/flexalloc_xnvme_env.c
@@ -199,37 +199,37 @@ fla_xne_sync_strp_seq_x(struct xnvme_dev *dev, const uint64_t offset, uint64_t n
   int err;
   struct fla_async_cb_args cb_args = { 0 };
   const struct xnvme_geo *geo = xnvme_dev_get_geo(dev);
-  uint32_t strp_num = sp->strp_num;
-  uint32_t strp_sz = sp->strp_sz;
+  uint32_t strp_nobjs = sp->strp_nobjs;
+  uint32_t strp_nbytes = sp->strp_nbytes;
   uint64_t obj_len = sp->obj_len;
-  uint32_t strp_blks = (strp_sz / geo->lba_nbytes) - 1;
+  uint32_t strp_blks = (strp_nbytes / geo->lba_nbytes) - 1;
   uint64_t bytes_xfer = 0, strp_offset = offset;
   char *strp_buf = (char *)buf;
 
-  // Nbytes must be a multiple of strp_num * strp_sz
-  if (nbytes % (strp_num * strp_sz))
+  // Nbytes must be a multiple of strp_nobjs * strp_nbytes
+  if (nbytes % (strp_nobjs * strp_nbytes))
   {
     err = -1;
-    FLA_ERR(err, "Striped write must be a multiple of strp_sz and nbytes");
+    FLA_ERR(err, "Striped write must be a multiple of strp_nbytes and nbytes");
     goto exit;
   }
 
   // Make sure offset aligns on strp boundary
-  if (offset % strp_sz)
+  if (offset % strp_nbytes)
   {
     err = -1;
     FLA_ERR(err, "Striped write offset must be aligned to strp sz");
     goto exit;
   }
 
-  if (nbytes/strp_num < strp_sz)
+  if (nbytes/strp_nobjs < strp_nbytes)
   {
     err = -1;
-    FLA_ERR(err, "Num bytes not large enough for strp_sz * strp_num");
+    FLA_ERR(err, "Num bytes not large enough for strp_nbytes * strp_nobjs");
     goto exit;
   }
 
-  err = xnvme_queue_init(dev, strp_num, 0, &queue);
+  err = xnvme_queue_init(dev, strp_nobjs, 0, &queue);
   if (FLA_ERR(err, "xnvme_queue_init"))
     goto exit;
 
@@ -238,15 +238,15 @@ fla_xne_sync_strp_seq_x(struct xnvme_dev *dev, const uint64_t offset, uint64_t n
   while (bytes_xfer != nbytes)
   {
 
-    for (uint32_t strp=0; strp < strp_num;)
+    for (uint32_t strp=0; strp < strp_nobjs;)
     {
       struct xnvme_cmd_ctx *ctx = xnvme_queue_get_cmd_ctx(queue);
       uint64_t slba = (strp_offset/geo->lba_nbytes) + (strp * obj_len);
 submit:
       if (write)
-        err = xnvme_nvm_write(ctx, nsid, slba, strp_blks, strp_buf + (strp * strp_sz), NULL);
+        err = xnvme_nvm_write(ctx, nsid, slba, strp_blks, strp_buf + (strp * strp_nbytes), NULL);
       else
-        err = xnvme_nvm_read(ctx, nsid, slba, strp_blks, strp_buf + (strp * strp_sz), NULL);
+        err = xnvme_nvm_read(ctx, nsid, slba, strp_blks, strp_buf + (strp * strp_nbytes), NULL);
 
       switch (err)
       {
@@ -269,9 +269,9 @@ next:
     }
 
     err = xnvme_queue_wait(queue);
-    bytes_xfer += strp_sz * strp_num;
-    strp_buf += strp_sz * strp_num;
-    strp_offset += strp_sz;
+    bytes_xfer += strp_nbytes * strp_nobjs;
+    strp_buf += strp_nbytes * strp_nobjs;
+    strp_offset += strp_nbytes;
     if (FLA_ERR(cb_args.ecount, "Error completing async IO\n"))
       goto exit;
 

--- a/src/flexalloc_xnvme_env.h
+++ b/src/flexalloc_xnvme_env.h
@@ -12,8 +12,8 @@
 
 struct fla_sync_strp_params
 {
-  uint32_t strp_num;
-  uint32_t strp_sz;
+  uint32_t strp_nobjs;
+  uint32_t strp_nbytes;
   uint64_t obj_len;
 };
 

--- a/src/flexalloc_xnvme_env.h
+++ b/src/flexalloc_xnvme_env.h
@@ -31,8 +31,8 @@ fla_xne_sync_seq_w_naddrs(struct xnvme_dev * dev, const uint64_t slba, const uin
                           void const * buf);
 
 int
-fla_xne_sync_strp_seq_x(struct xnvme_dev *dev, const uint64_t offset, uint64_t nbytes,
-                        void const *buf, struct fla_sync_strp_params *sp, bool write);
+fla_xne_sync_strp_seq_x(struct xnvme_dev *dev, uint64_t const offset, uint64_t nbytes,
+                        void const *buf, struct fla_sync_strp_params const * const sp, bool write);
 
 int
 /**

--- a/src/flexalloc_znd.c
+++ b/src/flexalloc_znd.c
@@ -89,7 +89,7 @@ fla_object_seal(struct flexalloc *fs, struct fla_pool const *pool_handle, struct
   uint64_t obj_slba = fla_object_slba(fs, obj, pool_handle);
   uint32_t obj_zn = obj_slba / fs->geo.nzsect;
   struct fla_pool_entry *pool_entry = &fs->pools.entries[pool_handle->ndx];
-  uint32_t strps = pool_entry->strp_num;
+  uint32_t strps = pool_entry->strp_nobjs;
 
   for (uint32_t strp = 0; strp < strps; strp++)
   {

--- a/src/libflexalloc.h
+++ b/src/libflexalloc.h
@@ -307,13 +307,13 @@ fla_object_seal(struct flexalloc *fs, struct fla_pool const *pool_handle, struct
  *
  * @param fs flexalloc system handle
  * @param pool_handle flexalloc pool handle to set as being striped
- * @param strp_num number of objects to stripe across
- * @param strp_sz size of each stripe chunk in bytes
+ * @param strp_nobjs number of objects to stripe across
+ * @param strp_nbytes size of each stripe chunk in bytes
  * @return int indicating if pool striping parameters were applied
  */
 int
-fla_pool_set_strp(struct flexalloc *fs, struct fla_pool const *pool_handle, uint32_t strp_num,
-                  uint32_t strp_sz);
+fla_pool_set_strp(struct flexalloc *fs, struct fla_pool const *pool_handle, uint32_t strp_nobjs,
+                  uint32_t strp_nbytes);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This PR allows the stripped reads to be less than the strp_nobjs size.

Also notice that I have changed the name of the variables to include the unis. This will make it easier to understand from just looking at the var:
strp_nbytes -> is the size of the strip within one FlexAlloc object.
strp_nobjs -> Number of FlexAlloc objects encompassed by the stripe object

The meat of this PR is in the b978c3f04811fade74dd9cfe43064ff08e8f870a commit