### PR TITLE
fio ioengine cleanups

### DIFF
--- a/fio-ioengine/flexalloc.c
+++ b/fio-ioengine/flexalloc.c
@@ -307,7 +307,8 @@ static int fio_flexalloc_init(struct thread_data *td)
 		ret = 1;
 	}
 
-	if (!td->o.use_thread) {
+	/* threads are required when not in daemon mode */
+	if (!td->o.use_thread && !o->daemon_uri) {
 		log_err("flexalloc: thread=1 must be set for the flexalloc ioengine\n");
 		ret = 1;
 	}
@@ -337,17 +338,13 @@ static int fio_flexalloc_init(struct thread_data *td)
 	if (daemon_mode(o))
 	{
 		ret = fio_flexalloc_open_daemon(fad, o);
-		if (ret) {
-			log_err("flexalloc: unable to open file system\n");
-			goto done;
-		}
 	} else {
 		pthread_mutex_lock(&fa_mutex);
 		ret = fio_flexalloc_open_direct(o->dev_uri, o->md_dev_uri, td->thread_number, &fad->fs);
-		if (ret) {
-			log_err("flexalloc: unable to open file system\n");
-			goto done;
-		}
+	}
+	if (ret) {
+		log_err("flexalloc: unable to open file system\n");
+		goto done;
 	}
 
 	/*

--- a/fio-ioengine/flexalloc.fio
+++ b/fio-ioengine/flexalloc.fio
@@ -1,12 +1,14 @@
 # this assumes that a flexalloc file system
 # has been created on /dev/ram0
 [test]
-ioengine=external:./flexalloc.o
+ioengine=external:/usr/local/lib/x86_64-linux-gnu/libflexalloc-fio-engine.so
 rw=randwrite
 verify=crc32c
 direct=1				# required for buffer alignment
 thread=1				# required for sharing FS handles
+					# threads not required for daemon mode
 dev_uri=/dev/ram0			# device where FS resides
+#daemon_uri=/tmp/flexalloc.socket	# use this instead for daemon mode
 filesize=2M				# size of each object
 nrfiles=100				# number of objects
 poolname=testpool


### PR DESCRIPTION
Here are a couple patches with some small fio ioengine-related cleanups:

- get rid of some duplicated error handling code and drop the thread requirement when in daemon mode
- add some notes to the sample job file about daemon mode and use the location where the external ioengine is installed

Testing
- test job run
```
root@ubuntu:~/flexalloc-dev/flexalloc# fio fio-ioengine/flexalloc.fio
test: (g=0): rw=randwrite, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=flexalloc, iodepth=1
fio-3.29-112-gc3773
Starting 1 thread

test: (groupid=0, jobs=1): err= 0: pid=14181: Tue Mar  1 01:47:30 2022
  read: IOPS=483k, BW=1887MiB/s (1978MB/s)(200MiB/106msec)
    clat (nsec): min=969, max=21259, avg=1456.41, stdev=437.92
     lat (nsec): min=996, max=21286, avg=1484.20, stdev=439.07
    clat percentiles (nsec):
     |  1.00th=[ 1064],  5.00th=[ 1272], 10.00th=[ 1320], 20.00th=[ 1352],
     | 30.00th=[ 1368], 40.00th=[ 1384], 50.00th=[ 1416], 60.00th=[ 1448],
     | 70.00th=[ 1480], 80.00th=[ 1576], 90.00th=[ 1656], 95.00th=[ 1704],
     | 99.00th=[ 1848], 99.50th=[ 1912], 99.90th=[ 8384], 99.95th=[12352],
     | 99.99th=[18304]
  write: IOPS=139k, BW=543MiB/s (570MB/s)(200MiB/368msec); 0 zone resets
    clat (nsec): min=1148, max=1079.0k, avg=5360.92, stdev=22008.57
     lat (usec): min=2, max=1080, avg= 6.82, stdev=22.13
    clat percentiles (nsec):
     |  1.00th=[  1208],  5.00th=[  1240], 10.00th=[  1256], 20.00th=[  1304],
     | 30.00th=[  1352], 40.00th=[  1624], 50.00th=[  3792], 60.00th=[  5152],
     | 70.00th=[  6176], 80.00th=[  8640], 90.00th=[ 10432], 95.00th=[ 11456],
     | 99.00th=[ 17280], 99.50th=[ 23168], 99.90th=[ 63232], 99.95th=[733184],
     | 99.99th=[806912]
  lat (nsec)   : 1000=0.04%
  lat (usec)   : 2=72.22%, 4=4.85%, 10=16.40%, 20=6.12%, 50=0.32%
  lat (usec)   : 100=0.01%, 250=0.01%, 500=0.01%, 750=0.03%, 1000=0.01%
  lat (msec)   : 2=0.01%
  cpu          : usr=36.23%, sys=63.35%, ctx=2, majf=0, minf=1202
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwts: total=51200,51200,0,0 short=0,0,0,0 dropped=0,0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=1

Run status group 0 (all jobs):
   READ: bw=1887MiB/s (1978MB/s), 1887MiB/s-1887MiB/s (1978MB/s-1978MB/s), io=200MiB (210MB), run=106-106msec
  WRITE: bw=543MiB/s (570MB/s), 543MiB/s-543MiB/s (570MB/s-570MB/s), io=200MiB (210MB), run=368-368msec
```
- threads required in direct mode
  - job 1: omitting threads is still an error
  - job 2: adding thread=1 lets the job run
```
root@ubuntu:~/flexalloc-dev# fio --name=test --ioengine=external:/usr/local/lib/x86_64-linux-gnu/libflexalloc-fio-engine.so --rw=randwrite --direct=1 --dev_uri=/dev/ram0 --filesize=2M --nrfiles=100 --time_based --runtime=30s
test: (g=0): rw=randwrite, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=flexalloc, iodepth=1
fio-3.29-112-gc3773
Starting 1 process
flexalloc: thread=1 must be set for the flexalloc ioengine
fio: io engine flexalloc init failed.
fio: pid=14116, err=1/


Run status group 0 (all jobs):
root@ubuntu:~/flexalloc-dev# fio --name=test --ioengine=external:/usr/local/lib/x86_64-linux-gnu/libflexalloc-fio-engine.so --rw=randwrite --direct=1 --dev_uri=/dev/ram0 --filesize=2M --nrfiles=100 --time_based --runtime=30s --thread=1
test: (g=0): rw=randwrite, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=flexalloc, iodepth=1
fio-3.29-112-gc3773
Starting 1 thread
Jobs: 1 (f=100): [w(1)][100.0%][w=1718MiB/s][w=440k IOPS][eta 00m:00s]
test: (groupid=0, jobs=1): err= 0: pid=14119: Tue Mar  1 01:35:36 2022
  write: IOPS=439k, BW=1714MiB/s (1798MB/s)(50.2GiB/30001msec); 0 zone resets
    clat (nsec): min=950, max=4079.3k, avg=1991.33, stdev=2117.86
     lat (nsec): min=997, max=4079.3k, avg=2040.07, stdev=2119.01
    clat percentiles (nsec):
     |  1.00th=[ 1640],  5.00th=[ 1736], 10.00th=[ 1768], 20.00th=[ 1784],
     | 30.00th=[ 1816], 40.00th=[ 1832], 50.00th=[ 1848], 60.00th=[ 1880],
     | 70.00th=[ 1928], 80.00th=[ 2096], 90.00th=[ 2544], 95.00th=[ 2672],
     | 99.00th=[ 2960], 99.50th=[ 3184], 99.90th=[ 7264], 99.95th=[12992],
     | 99.99th=[18560]
   bw (  MiB/s): min= 1515, max= 1739, per=100.00%, avg=1716.61, stdev=31.97, samples=59
   iops        : min=388082, max=445396, avg=439453.36, stdev=8184.35, samples=59
  lat (nsec)   : 1000=0.01%
  lat (usec)   : 2=76.28%, 4=23.48%, 10=0.15%, 20=0.09%, 50=0.01%
  lat (usec)   : 100=0.01%, 250=0.01%, 500=0.01%, 1000=0.01%
  lat (msec)   : 4=0.01%, 10=0.01%
  cpu          : usr=31.10%, sys=68.89%, ctx=90, majf=0, minf=2
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwts: total=0,13166835,0,0 short=0,0,0,0 dropped=0,0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=1

Run status group 0 (all jobs):
  WRITE: bw=1714MiB/s (1798MB/s), 1714MiB/s-1714MiB/s (1798MB/s-1798MB/s), io=50.2GiB (53.9GB), run=30001-30001msec
```

- Threads do no harm in daemon mode but are not required
  - job 1: adding thread=1 still works (I interrupted this job with ^C after 7s)
  - job 2: omitting thread=1 and having jobs=2 works
```
root@ubuntu:~/flexalloc-dev# fio --name=test2 --ioengine=external:/usr/local/lib/x86_64-linux-gnu/libflexalloc-fio-engine.so --rw=randwrite --direct=1 --daemon_uri=/tmp/flexalloc.socket --filesize=2M --nrfiles=100 --time_based --runtime=30s --thread=1
test2: (g=0): rw=randwrite, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=flexalloc, iodepth=1
fio-3.29-112-gc3773
Starting 1 thread
flexalloc DBG connected to server!!
flexalloc DBG identity{type: 1000, version: 1}
^Cbs: 1 (f=100): [w(1)][23.3%][w=1735MiB/s][w=444k IOPS][eta 00m:23s]
fio: terminating on signal 2

test2: (groupid=0, jobs=1): err= 0: pid=14136: Tue Mar  1 01:36:15 2022
  write: IOPS=434k, BW=1697MiB/s (1779MB/s)(11.6GiB/7029msec); 0 zone resets
    clat (nsec): min=960, max=1172.6k, avg=1986.10, stdev=1901.43
     lat (nsec): min=1008, max=1172.7k, avg=2034.37, stdev=1902.83
    clat percentiles (nsec):
     |  1.00th=[ 1640],  5.00th=[ 1720], 10.00th=[ 1736], 20.00th=[ 1768],
     | 30.00th=[ 1784], 40.00th=[ 1816], 50.00th=[ 1832], 60.00th=[ 1864],
     | 70.00th=[ 1896], 80.00th=[ 2040], 90.00th=[ 2512], 95.00th=[ 2672],
     | 99.00th=[ 3920], 99.50th=[ 5408], 99.90th=[10944], 99.95th=[13120],
     | 99.99th=[18560]
   bw (  MiB/s): min= 1236, max= 1746, per=100.00%, avg=1699.14, stdev=133.15, samples=14
   iops        : min=316624, max=447022, avg=434979.71, stdev=34087.43, samples=14
  lat (nsec)   : 1000=0.01%
  lat (usec)   : 2=78.00%, 4=21.06%, 10=0.82%, 20=0.11%, 50=0.01%
  lat (usec)   : 100=0.01%
  lat (msec)   : 2=0.01%
  cpu          : usr=30.12%, sys=69.82%, ctx=132, majf=0, minf=0
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwts: total=0,3053621,0,0 short=0,0,0,0 dropped=0,0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=1

Run status group 0 (all jobs):
  WRITE: bw=1697MiB/s (1779MB/s), 1697MiB/s-1697MiB/s (1779MB/s-1779MB/s), io=11.6GiB (12.5GB), run=7029-7029msec

root@ubuntu:~/flexalloc-dev# fio --name=test2 --ioengine=external:/usr/local/lib/x86_64-linux-gnu/libflexalloc-fio-engine.so --rw=randwrite --direct=1 --daemon_uri=/tmp/flexalloc.socket --filesize=2M --nrfiles=100 --time_based --runtime=30s --numjobs=2 --group_reporting
test2: (g=0): rw=randwrite, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=flexalloc, iodepth=1
...
fio-3.29-112-gc3773
Starting 2 processes
flexalloc DBG flexalloc DBG connected to server!!
connected to server!!
flexalloc DBG identity{type: 1000, version: 1}
flexalloc DBG identity{type: 1000, version: 1}
Jobs: 2 (f=200): [w(2)][100.0%][w=3377MiB/s][w=864k IOPS][eta 00m:00s]
test2: (groupid=0, jobs=2): err= 0: pid=14143: Tue Mar  1 01:37:05 2022
  write: IOPS=812k, BW=3170MiB/s (3324MB/s)(92.9GiB/30001msec); 0 zone resets
    clat (nsec): min=988, max=3035.6k, avg=2152.97, stdev=2238.84
     lat (nsec): min=1030, max=3035.7k, avg=2205.08, stdev=2241.32
    clat percentiles (nsec):
     |  1.00th=[ 1720],  5.00th=[ 1800], 10.00th=[ 1832], 20.00th=[ 1864],
     | 30.00th=[ 1896], 40.00th=[ 1928], 50.00th=[ 1960], 60.00th=[ 2024],
     | 70.00th=[ 2160], 80.00th=[ 2512], 90.00th=[ 2672], 95.00th=[ 2832],
     | 99.00th=[ 3120], 99.50th=[ 3568], 99.90th=[13376], 99.95th=[18304],
     | 99.99th=[19072]
   bw (  MiB/s): min= 2519, max= 3434, per=100.00%, avg=3171.54, stdev=122.62, samples=118
   iops        : min=645012, max=879192, avg=811915.58, stdev=31391.60, samples=118
  lat (nsec)   : 1000=0.01%
  lat (usec)   : 2=56.70%, 4=42.91%, 10=0.20%, 20=0.18%, 50=0.01%
  lat (usec)   : 100=0.01%, 250=0.01%, 500=0.01%, 750=0.01%, 1000=0.01%
  lat (msec)   : 2=0.01%, 4=0.01%
  cpu          : usr=29.40%, sys=70.57%, ctx=512, majf=0, minf=16
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwts: total=0,24349391,0,0 short=0,0,0,0 dropped=0,0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=1

Run status group 0 (all jobs):
  WRITE: bw=3170MiB/s (3324MB/s), 3170MiB/s-3170MiB/s (3324MB/s-3324MB/s), io=92.9GiB (99.7GB), run=30001-30001msec
```
