### PR TITLE
Jag/general striped transfers

### DIFF
--- a/src/flexalloc_mm.c
+++ b/src/flexalloc_mm.c
@@ -750,8 +750,8 @@ fla_print_pool_entries(struct flexalloc *fs)
     fprintf(stderr, "Pool Entry %"PRIu32"(%p)\n", npool, pool_entry);
     fprintf(stderr, "|  obj_nlb : %"PRIu32"\n", pool_entry->obj_nlb);
     fprintf(stderr, "|  root_obj_hndl : %"PRIu64"\n", pool_entry->root_obj_hndl);
-    fprintf(stderr, "|  strp_num : %"PRIu32"\n", pool_entry->strp_num);
-    fprintf(stderr, "|  strp_sz : %"PRIu32"\n", pool_entry->strp_sz);
+    fprintf(stderr, "|  strp_nobjs : %"PRIu32"\n", pool_entry->strp_nobjs);
+    fprintf(stderr, "|  strp_nbytes : %"PRIu32"\n", pool_entry->strp_nbytes);
     fprintf(stderr, "|  PoolName : %s\n", pool_entry->name);
     fprintf(stderr, "|  Max Number of Objects In Slab %"PRIu32"\n", pool_entry->slab_nobj);
     fprintf(stderr, "|  Slabs:\n");
@@ -773,7 +773,8 @@ fla_print_pool_entries(struct flexalloc *fs)
   }
 }
 
-void fla_print_fs(struct flexalloc *fs)
+void
+fla_print_fs(struct flexalloc *fs)
 {
   fla_print_geo(fs);
   fla_print_pool_entries(fs);
@@ -826,23 +827,24 @@ fla_pool_entry_reset(struct fla_pool_entry *pool_entry, const char *name, int na
   pool_entry->full_slabs = FLA_LINKED_LIST_NULL;
   pool_entry->partial_slabs = FLA_LINKED_LIST_NULL;
   pool_entry->root_obj_hndl = FLA_ROOT_OBJ_NONE;
-  pool_entry->strp_num = 1; // By default we don't stripe across objects
+  pool_entry->strp_nobjs = 1; // By default we don't stripe across objects
 }
 
 int
-fla_pool_set_strp(struct flexalloc *fs, struct fla_pool *ph, uint32_t strp_num, uint32_t strp_sz)
+fla_pool_set_strp(struct flexalloc *fs, struct fla_pool *ph, uint32_t strp_nobjs,
+                  uint32_t strp_nbytes)
 {
   struct fla_pool_entry *pool_entry = &fs->pools.entries[ph->ndx];
   const struct xnvme_geo * geo = xnvme_dev_get_geo(fs->dev.dev);
 
-  if (FLA_ERR(strp_sz > geo->mdts_nbytes, "Strp sz > mdts for device"))
+  if (FLA_ERR(strp_nbytes > geo->mdts_nbytes, "Strp sz > mdts for device"))
     return -1;
 
-  if (FLA_ERR(strp_num > pool_entry->slab_nobj, "Strp sz > max obj in slab"))
+  if (FLA_ERR(strp_nobjs > pool_entry->slab_nobj, "Strp sz > max obj in slab"))
     return -1;
 
-  pool_entry->strp_num = strp_num;
-  pool_entry->strp_sz = strp_sz;
+  pool_entry->strp_nobjs = strp_nobjs;
+  pool_entry->strp_nbytes = strp_nbytes;
 
   return 0;
 }
@@ -1073,7 +1075,7 @@ fla_slab_next_available_obj(struct flexalloc * fs, struct fla_slab_header * slab
     return err;
 
   pool_entry = &fs->pools.entries[slab->pool];
-  slab->refcount += pool_entry->strp_num;
+  slab->refcount += pool_entry->strp_nobjs;
 
   return err;
 }
@@ -1083,7 +1085,7 @@ fla_pool_best_slab_list(const struct fla_slab_header* slab,
                         struct fla_pool_entry * pool_entry)
 {
   return slab->refcount == 0 ? &pool_entry->empty_slabs
-         : slab->refcount + pool_entry->strp_num > pool_entry->slab_nobj ? &pool_entry->full_slabs
+         : slab->refcount + pool_entry->strp_nobjs > pool_entry->slab_nobj ? &pool_entry->full_slabs
          : &pool_entry->partial_slabs;
 }
 
@@ -1145,7 +1147,7 @@ fla_base_object_create(struct flexalloc * fs, struct fla_pool * pool_handle,
 
   from_head = fla_pool_best_slab_list(slab, pool_entry);
 
-  err = fla_slab_next_available_obj(fs, slab, obj, pool_entry->strp_num);
+  err = fla_slab_next_available_obj(fs, slab, obj, pool_entry->strp_nobjs);
   if(FLA_ERR(err, "fla_slab_next_available_obj()"))
   {
     goto exit;
@@ -1178,8 +1180,7 @@ fla_object_slba(struct flexalloc const * fs, struct fla_object const * obj,
                 const struct fla_pool * pool_handle)
 {
   const struct fla_pool_entry * pool_entry = &fs->pools.entries[pool_handle->ndx];
-  return fla_geo_slab_lb_off(fs, obj->slab_id)
-    + (pool_entry->obj_nlb * obj->entry_ndx);
+  return fla_geo_slab_lb_off(fs, obj->slab_id) + (pool_entry->obj_nlb * obj->entry_ndx);
 }
 
 uint64_t
@@ -1230,7 +1231,7 @@ fla_base_object_destroy(struct flexalloc *fs, struct fla_pool * pool_handle,
   if(FLA_ERR(err, "fla_slab_cache_obj_free()"))
     goto exit;
 
-  slab->refcount -= pool_entry->strp_num;
+  slab->refcount -= pool_entry->strp_nobjs;
   to_head = fla_pool_best_slab_list(slab, pool_entry);
 
   err = fla_hdll_remove(fs, slab, from_head);
@@ -1378,7 +1379,7 @@ fla_object_elba(struct flexalloc const * fs, struct fla_object const * obj,
 {
   const struct fla_pool_entry * pool_entry = &fs->pools.entries[pool_handle->ndx];
   return fla_geo_slab_lb_off(fs, obj->slab_id)
-    + (pool_entry->obj_nlb * (obj->entry_ndx + pool_entry->strp_num));
+         + (pool_entry->obj_nlb * (obj->entry_ndx + pool_entry->strp_nobjs));
 }
 
 uint64_t
@@ -1389,8 +1390,7 @@ fla_object_eoffset(struct flexalloc const * fs, struct fla_object const * obj,
 }
 
 int
-fla_object_read(const struct flexalloc * fs,
-                struct fla_pool const * pool_handle,
+fla_object_read(const struct flexalloc * fs, struct fla_pool const * pool_handle,
                 struct fla_object const * obj, void * buf, size_t r_offset, size_t r_len)
 {
   int err;
@@ -1400,7 +1400,7 @@ fla_object_read(const struct flexalloc * fs,
 
   obj_eoffset = fla_object_eoffset(fs, obj, pool_handle);
   obj_soffset = fla_object_soffset(fs, obj, pool_handle);
-  r_soffset = obj_soffset + (r_offset / pool_entry->strp_num);
+  r_soffset = obj_soffset + (r_offset / pool_entry->strp_nobjs);
   r_eoffset = r_soffset + r_len;
 
   slab_eoffset = (fla_geo_slab_lb_off(fs, obj->slab_id) + fs->geo.slab_nlb) * fs->geo.lb_nbytes;
@@ -1410,13 +1410,13 @@ fla_object_read(const struct flexalloc * fs,
   if((err = FLA_ERR(obj_eoffset < r_eoffset, "Read outside of an object")))
     goto exit;
 
-  if (pool_entry->strp_num == 1)
+  if (pool_entry->strp_nobjs == 1)
     err = fla_xne_sync_seq_r_nbytes(fs->dev.dev, r_soffset, r_len, buf);
   else
   {
-    sp.strp_num = pool_entry->strp_num;
-    sp.strp_sz = pool_entry->strp_sz;
-    sp.obj_len = pool_entry->obj_nlb;
+    sp.strp_nobjs = pool_entry->strp_nobjs;
+    sp.strp_nbytes = pool_entry->strp_nbytes;
+    sp.obj_nlbs = pool_entry->obj_nlb;
     err = fla_xne_sync_strp_seq_x(fs->dev.dev, r_soffset, r_len, buf, &sp, false);
   }
 
@@ -1439,7 +1439,7 @@ fla_object_write(struct flexalloc * fs, struct fla_pool const * pool_handle,
 
   obj_eoffset = fla_object_eoffset(fs, obj, pool_handle);
   obj_soffset = fla_object_soffset(fs, obj, pool_handle);
-  w_soffset = obj_soffset + (w_offset / pool_entry->strp_num);
+  w_soffset = obj_soffset + (w_offset / pool_entry->strp_nobjs);
   w_eoffset = w_soffset + w_len;
   obj_zn = w_soffset / (fs->geo.nzsect * fla_fs_lb_nbytes(fs));
 
@@ -1453,13 +1453,13 @@ fla_object_write(struct flexalloc * fs, struct fla_pool const * pool_handle,
   if((err = FLA_ERR(obj_eoffset < w_eoffset, "Write outside of an object")))
     goto exit;
 
-  if (pool_entry->strp_num == 1)
+  if (pool_entry->strp_nobjs == 1)
     err = fla_xne_sync_seq_w_nbytes(fs->dev.dev, w_soffset, w_len, buf);
   else
   {
-    sp.strp_num = pool_entry->strp_num;
-    sp.strp_sz = pool_entry->strp_sz;
-    sp.obj_len = pool_entry->obj_nlb;
+    sp.strp_nobjs = pool_entry->strp_nobjs;
+    sp.strp_nbytes = pool_entry->strp_nbytes;
+    sp.obj_nlbs = pool_entry->obj_nlb;
     err = fla_xne_sync_strp_seq_x(fs->dev.dev, w_soffset, w_len, buf, &sp, true);
   }
 

--- a/src/flexalloc_mm.h
+++ b/src/flexalloc_mm.h
@@ -95,14 +95,17 @@ struct fla_pool_entry
   ///
   /// Pools can have any valid flexalloc object set as a root object
   uint64_t root_obj_hndl;
+
   /// Num of objects to stripe across
   ///
   /// Pools may optionally hand out striped objects
-  uint32_t strp_num;
+
+  uint32_t strp_nobjs;
   /// Size of each stripe chunk
   ///
-  /// Must be set if we ste strp_num
-  uint32_t strp_sz;
+  /// Must be set if we set strp_nobjs
+
+  uint32_t strp_nbytes;
   /// Human-readable cache identifier
   ///
   /// The cache name is primarily used for debugging statistics

--- a/src/flexalloc_mm.h
+++ b/src/flexalloc_mm.h
@@ -99,13 +99,15 @@ struct fla_pool_entry
   /// Num of objects to stripe across
   ///
   /// Pools may optionally hand out striped objects
-
   uint32_t strp_nobjs;
-  /// Size of each stripe chunk
-  ///
-  /// Must be set if we set strp_nobjs
 
+  /// Number of bytes of each stripe chunk
+  ///
+  /// When striped, each fla object is subdivided into stripe
+  /// subsection or chunks.
+  /// Must be set if we set strp_nobjs
   uint32_t strp_nbytes;
+
   /// Human-readable cache identifier
   ///
   /// The cache name is primarily used for debugging statistics

--- a/src/flexalloc_slabcache.h
+++ b/src/flexalloc_slabcache.h
@@ -174,7 +174,7 @@ fla_slab_cache_elem_drop(struct fla_slab_flist_cache *cache, uint32_t slab_id);
  * @param cache slab freelist cache
  * @param slab_id id of the slab to reserve an entry from
  * @param obj_id pointer to a object id struct - to be populated if operation is successful
- * @parm strp_num Number of objects to stripe across
+ * @param strp_nobjs Number of objects to stripe accross
  *
  * @return On success 0, with obj_id set to uniquely identify the reserved object.
  * Non-zero return values indicate an error. FLA_SLAB_CACHE_INVALID_STATE means
@@ -183,7 +183,7 @@ fla_slab_cache_elem_drop(struct fla_slab_flist_cache *cache, uint32_t slab_id);
  */
 int
 fla_slab_cache_obj_alloc(struct fla_slab_flist_cache *cache, uint32_t slab_id,
-                         struct fla_object *obj_id, uint32_t strp_num);
+                         struct fla_object *obj_id, uint32_t strp_nobjs);
 
 /**
  * Release object entry reservation.

--- a/src/flexalloc_xnvme_env.c
+++ b/src/flexalloc_xnvme_env.c
@@ -199,37 +199,37 @@ fla_xne_sync_strp_seq_x(struct xnvme_dev *dev, const uint64_t offset, uint64_t n
   int err;
   struct fla_async_cb_args cb_args = { 0 };
   const struct xnvme_geo *geo = xnvme_dev_get_geo(dev);
-  uint32_t strp_num = sp->strp_num;
-  uint32_t strp_sz = sp->strp_sz;
-  uint64_t obj_len = sp->obj_len;
-  uint32_t strp_blks = (strp_sz / geo->lba_nbytes) - 1;
+  uint32_t strp_nobjs = sp->strp_nobjs;
+  uint32_t strp_nbytes = sp->strp_nbytes;
+  uint64_t obj_nlbs = sp->obj_nlbs;
+  uint32_t strp_blks = (strp_nbytes / geo->lba_nbytes) - 1;
   uint64_t bytes_xfer = 0, strp_offset = offset;
   char *strp_buf = (char *)buf;
 
-  // Nbytes must be a multiple of strp_num * strp_sz
-  if (nbytes % (strp_num * strp_sz))
+  // Nbytes must be a multiple of strp_nobjs * strp_nbytes
+  if (nbytes % (strp_nobjs * strp_nbytes))
   {
     err = -1;
-    FLA_ERR(err, "Striped write must be a multiple of strp_sz and nbytes");
+    FLA_ERR(err, "Striped write must be a multiple of strp_nbytes and nbytes");
     goto exit;
   }
 
   // Make sure offset aligns on strp boundary
-  if (offset % strp_sz)
+  if (offset % strp_nbytes)
   {
     err = -1;
     FLA_ERR(err, "Striped write offset must be aligned to strp sz");
     goto exit;
   }
 
-  if (nbytes/strp_num < strp_sz)
+  if (nbytes/strp_nobjs < strp_nbytes)
   {
     err = -1;
-    FLA_ERR(err, "Num bytes not large enough for strp_sz * strp_num");
+    FLA_ERR(err, "Num bytes not large enough for strp_nbytes * strp_nobjs");
     goto exit;
   }
 
-  err = xnvme_queue_init(dev, strp_num, 0, &queue);
+  err = xnvme_queue_init(dev, strp_nobjs, 0, &queue);
   if (FLA_ERR(err, "xnvme_queue_init"))
     goto exit;
 
@@ -238,15 +238,15 @@ fla_xne_sync_strp_seq_x(struct xnvme_dev *dev, const uint64_t offset, uint64_t n
   while (bytes_xfer != nbytes)
   {
 
-    for (uint32_t strp=0; strp < strp_num;)
+    for (uint32_t strp=0; strp < strp_nobjs;)
     {
       struct xnvme_cmd_ctx *ctx = xnvme_queue_get_cmd_ctx(queue);
-      uint64_t slba = (strp_offset/geo->lba_nbytes) + (strp * obj_len);
+      uint64_t slba = (strp_offset/geo->lba_nbytes) + (strp * obj_nlbs);
 submit:
       if (write)
-        err = xnvme_nvm_write(ctx, nsid, slba, strp_blks, strp_buf + (strp * strp_sz), NULL);
+        err = xnvme_nvm_write(ctx, nsid, slba, strp_blks, strp_buf + (strp * strp_nbytes), NULL);
       else
-        err = xnvme_nvm_read(ctx, nsid, slba, strp_blks, strp_buf + (strp * strp_sz), NULL);
+        err = xnvme_nvm_read(ctx, nsid, slba, strp_blks, strp_buf + (strp * strp_nbytes), NULL);
 
       switch (err)
       {
@@ -269,9 +269,9 @@ next:
     }
 
     err = xnvme_queue_wait(queue);
-    bytes_xfer += strp_sz * strp_num;
-    strp_buf += strp_sz * strp_num;
-    strp_offset += strp_sz;
+    bytes_xfer += strp_nbytes * strp_nobjs;
+    strp_buf += strp_nbytes * strp_nobjs;
+    strp_offset += strp_nbytes;
     if (FLA_ERR(cb_args.ecount, "Error completing async IO\n"))
       goto exit;
 

--- a/src/flexalloc_xnvme_env.h
+++ b/src/flexalloc_xnvme_env.h
@@ -12,9 +12,9 @@
 
 struct fla_sync_strp_params
 {
-  uint32_t strp_num;
-  uint32_t strp_sz;
-  uint64_t obj_len;
+  uint32_t strp_nobjs;
+  uint32_t strp_nbytes;
+  uint64_t obj_nlbs;
 };
 
 /**

--- a/src/flexalloc_xnvme_env.h
+++ b/src/flexalloc_xnvme_env.h
@@ -10,11 +10,34 @@
 #include <libxnvme.h>
 #include <libxnvme_lba.h>
 
-struct fla_sync_strp_params
+struct fla_strp_params
 {
+  /// Num of objects to stripe across
   uint32_t strp_nobjs;
-  uint32_t strp_nbytes;
-  uint64_t obj_nlbs;
+
+  /// Number of bytes of each stripe chunk
+  uint32_t strp_chunk_nbytes;
+
+  /// Number of lbs in a non-striped object
+  uint64_t faobj_nlbs;
+
+  /// Start offset within object (slba == 0)
+  uint64_t xfer_snbytes;
+
+  /// Number of bytes to transfer
+  uint64_t xfer_nbytes;
+
+  /// Total bytes in a striped object
+  uint64_t strp_obj_tnbytes;
+
+  /// striped object offset within device
+  uint64_t strp_obj_start_nbytes;
+
+  /// the device logical block size
+  uint32_t dev_lba_nbytes;
+
+  /// Wether to write or not
+  bool write;
 };
 
 /**
@@ -31,8 +54,7 @@ fla_xne_sync_seq_w_naddrs(struct xnvme_dev * dev, const uint64_t slba, const uin
                           void const * buf);
 
 int
-fla_xne_sync_strp_seq_x(struct xnvme_dev *dev, const uint64_t offset, uint64_t nbytes,
-                        void const *buf, struct fla_sync_strp_params *sp, bool write);
+fla_xne_async_strp_seq_x(struct xnvme_dev *dev, void const *buf, struct fla_strp_params *sp);
 
 int
 /**

--- a/src/flexalloc_znd.c
+++ b/src/flexalloc_znd.c
@@ -89,7 +89,7 @@ fla_object_seal(struct flexalloc *fs, struct fla_pool const *pool_handle, struct
   uint64_t obj_slba = fla_object_slba(fs, obj, pool_handle);
   uint32_t obj_zn = obj_slba / fs->geo.nzsect;
   struct fla_pool_entry *pool_entry = &fs->pools.entries[pool_handle->ndx];
-  uint32_t strps = pool_entry->strp_num;
+  uint32_t strps = pool_entry->strp_nobjs;
 
   for (uint32_t strp = 0; strp < strps; strp++)
   {

--- a/src/libflexalloc.h
+++ b/src/libflexalloc.h
@@ -295,13 +295,13 @@ fla_object_seal(struct flexalloc *fs, struct fla_pool const *pool_handle, struct
  *
  * @param fs flexalloc system handle
  * @param pool_handle flexalloc pool handle to set as being striped
- * @param strp_num number of objects to stripe across
- * @param strp_sz size of each stripe chunk in bytes
+ * @param strp_nobjs number of objects to stripe across
+ * @param strp_nbytes size of each stripe chunk in bytes
  * @return int indicating if pool striping parameters were applied
  */
 int
-fla_pool_set_strp(struct flexalloc *fs, struct fla_pool const *pool_handle, uint32_t strp_num,
-                  uint32_t strp_sz);
+fla_pool_set_strp(struct flexalloc *fs, struct fla_pool const *pool_handle, uint32_t strp_nobjs,
+                  uint32_t strp_nbytes);
 
 #ifdef __cplusplus
 }

--- a/tests/flexalloc_rt_object_unaligned_write.c
+++ b/tests/flexalloc_rt_object_unaligned_write.c
@@ -3,6 +3,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 #include "libflexalloc.h"
 #include "flexalloc.h"
 #include "flexalloc_util.h"
@@ -44,6 +45,8 @@ main(int argc, char **argv)
   struct fs_test_vals fs_vals;
 
   fs_vals.pool_handle_name = "mypool";
+
+  srand(getpid());
 
   err = fla_ut_dev_init(test_vals.blk_num, &dev);
   if (FLA_ERR(err, "fla_ut_dev_init()"))


### PR DESCRIPTION
A General striped function that does the following:
1. Generalizes the slba and elba of the xfer (read or write). We can now stripe write or read onto any striped object from any slba to any elba. except on ZNS, we need code that addresses starting in another point different than the write pointer.
2. Implements an async xfer using the async interface from xnvme.
3. Also changes the name of the strp structure to a more mnemonic versrion.