### PR TITLE
Tests: Reactivate the slab tests

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -85,9 +85,9 @@ xnvme_tests = {
 }
 
 core_tests = {
-  # 'ut_slab'
-  # : {'sources': 'tests/flexalloc_ut_slab.c',
-  #    'suite': 'core'},
+   'ut_slab'
+   : {'sources': 'tests/flexalloc_ut_slab.c',
+      'suite': 'core'},
   'rt_pool'
   : {'sources': 'tests/flexalloc_rt_pool.c',
      'suite': 'core'},


### PR DESCRIPTION
Signed-off-by: Joel Granados <j.granados@samsung.com>

This test used to make sure that we had the expected slab numbers and, by extension, the correct slab sizes. We removed it when we committed the change to tests on different devices. The issue then was that we did not have a way to calculate expected slab number values. I changed it in such a way as we do not depend on the block number nor the number of slabs.

In order to check, just make sure that all tests pass on your side.