### PR TITLE
Tets: Check FLA_LOOP_LBS to set block size

### DIFF
--- a/src/defines.h
+++ b/src/defines.h
@@ -1,7 +1,0 @@
-// Copyright (C) 2021 Joel Granados <j.granados@samsung.com>
-#ifndef __FLEXALLOC_DEFINES_H
-#define __FLEXALLOC_DEFINES_H
-
-#define FLA_LB_SIZE 512
-
-#endif /* __FLEXALLOC_DEFINES_H */

--- a/tests/flexalloc_tests_common.c
+++ b/tests/flexalloc_tests_common.c
@@ -121,7 +121,7 @@ fla_ut_lpbk_dev_alloc(uint64_t block_size, uint64_t nblocks,
 
   // Free loop number file descriptor?
   devnr = ioctl(loop_ctrl_fd, LOOP_CTL_GET_FREE);
-  if((err = FLA_ERR_ERRNO(devnr==-1, "ioctl()")))
+  if((err = FLA_ERR_ERRNO(devnr==-1, "ioctl() LOOP_CTL_GET_FREE")))
   {
     goto close_loop_ctrl;
   }
@@ -147,13 +147,13 @@ fla_ut_lpbk_dev_alloc(uint64_t block_size, uint64_t nblocks,
   }
 
   err = ioctl((*loop)->dev_fd, LOOP_SET_FD, (*loop)->bfile_fd);
-  if((err = FLA_ERR_ERRNO(err == -1, "ioctl()")))
+  if((err = FLA_ERR_ERRNO(err == -1, "ioctl() LOOP_SET_FD")))
   {
     goto close_backing_file;
   }
 
   err = ioctl((*loop)->dev_fd, LOOP_SET_BLOCK_SIZE, (*loop)->block_size);
-  if((err = FLA_ERR_ERRNO(err, "ioctl()")))
+  if((err = FLA_ERR_ERRNO(err, "ioctl() LOOP_SET_BLOCK_SIZE")))
   {
     goto teardown_loop;
   }
@@ -579,7 +579,7 @@ fla_ut_dev_init(uint64_t disk_min_blocks, struct fla_ut_dev *dev)
 
     xnvme_dev_close(xdev);
     if (FLA_ERR(dev->nblocks < disk_min_blocks,
-                "fla_ut_fs_create() - backing device disk too small for test requirements"))
+                "Backing device disk too small for test requirements"))
     {
       return FLA_ERR_ERROR;
     }
@@ -588,6 +588,13 @@ fla_ut_dev_init(uint64_t disk_min_blocks, struct fla_ut_dev *dev)
   {
     dev->_is_loop = 1;
     dev->lb_nbytes = 512;
+    if(getenv("FLA_LOOP_LBS") != NULL)
+    {
+      errno = 0;
+      dev->lb_nbytes = strtol(getenv("FLA_LOOP_LBS"), NULL, 10);
+      if ((err = FLA_ERR(errno != 0,"Could not properly convert FLA_LOOP_LBS")))
+        return err;
+    }
     dev->nblocks = disk_min_blocks;
     err = fla_ut_lpbk_dev_alloc(dev->lb_nbytes, disk_min_blocks, &dev->_loop);
     if(FLA_ERR(err, "fla_ut_lpbk_dev_alloc()"))

--- a/tests/flexalloc_tests_common.h
+++ b/tests/flexalloc_tests_common.h
@@ -101,12 +101,7 @@ fla_ut_dev_teardown(struct fla_ut_dev *dev);
 /**
  * Create a flexalloc instance using device if FLA_TEST_DEV is set, otherwise using loopback.
  *
- * @param slab_min_512byte_blocks minimum number of blocks (in units of 512B)
- *        to allocate per slab.
- *        Note that this number will be rounded up to match a multiple of the
- *        device's logical block size. E.g. specifying a slab size of 7 512B
- *        blocks for devices whose LB is 4KiB (8*512B) causes over-provisioning
- *        of 512B per slab.
+ * @param slab_min_blocks minimum number of blocks
  * @param npools number of pools to allocate space for in flexalloc
  * @param dev contains information related to which device type was selected,
  *            fields not prepended by underscore may be read.
@@ -114,7 +109,7 @@ fla_ut_dev_teardown(struct fla_ut_dev *dev);
  * @return 0 on success, error otherwise.
  */
 int
-fla_ut_fs_create(uint32_t slab_min_512byte_blocks, uint32_t npools,
+fla_ut_fs_create(uint32_t slab_min_blocks, uint32_t npools,
                  struct fla_ut_dev *dev, struct flexalloc **fs);
 
 /**


### PR DESCRIPTION
Signed-off-by: Joel Granados <j.granados@samsung.com>

To test you simple prepend FLA_LOOP_LBS=block_size_size to your regular `meson compile -C BUILD_DIR run-tests` and it will change the size of the loops that we are testing