### PR TITLE
MM: Print FS on error in object creation

### DIFF
--- a/src/flexalloc_util.h
+++ b/src/flexalloc_util.h
@@ -112,10 +112,13 @@ fla_err_errno_fl(const int condition, const char * message, const char * f,
   FLA_DBG_PRX;                                \
   fprintf(stderr, f, __VA_ARGS__);              \
   fflush(stderr);
+
+#define FLA_DBG_EXEC(statement) statement;
 #else
 #define FLA_DBG_PRX() ;
 #define FLA_DBG_PRINT(s) ;
 #define FLA_DBG_PRINTF(f, ...) ;
+#define FLA_DBG_EXEC(statement) ;
 #endif
 
 /* Ceiling division provided:


### PR DESCRIPTION
Signed-off-by: Joel Granados <j.granados@samsung.com>

This allows to do two things:
1. Execute whatever statement inside a debug macro. The statement will only get executed when you compile with buildtype debug
2. Use the fla_print_fs to print the current state of the flexalloc memeroy.