### PR TITLE
Jwd/sphinx

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -1,0 +1,50 @@
+name: Build docs
+
+on:
+  push:
+    branches:
+      - master
+      - jwd/sphinx
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  generate-docs:
+    runs-on: ubuntu-20.04
+
+    steps:
+    - name: Get source
+      uses: actions/checkout@v2
+
+    - name: Install doxygen
+      run: sudo apt-get install -y doxygen
+
+    - name: Prepare python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '>=3.9'
+
+    - name: Prepare Python virtual environment
+      uses: syphar/restore-virtualenv@v1
+      id: cache-docs-venv
+      with:
+        requirement_files: docs/requirements.txt
+
+    - name: Install requirements
+      run: pip install -r docs/requirements.txt
+      if: steps.cache-docs-venv.outputs.cache-hit != 'true'
+
+    - name: Generate docs
+      run: python docs/build_docs.py
+
+    - name: Publish docs
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./docs/build
+        user_name: 'github-actions[bot]'
+        user_email: 'github-actions[bot]@users.noreply.github.com'
+        force_orphan: true
+        publish_branch: gh-pages

--- a/.gitignore
+++ b/.gitignore
@@ -6,9 +6,6 @@ build
 *.build/
 debug
 
-# documentation
-apidocs
-
 # Prerequisites
 *.d
 

--- a/docs/.doxygen
+++ b/docs/.doxygen
@@ -32,7 +32,7 @@ DOXYFILE_ENCODING      = UTF-8
 # title of most generated pages and in a few other places.
 # The default value is: My Project.
 
-PROJECT_NAME           = "!FS"
+PROJECT_NAME           = "FlexAlloc"
 
 # The PROJECT_NUMBER tag can be used to enter a project or revision number. This
 # could be handy for archiving the generated documentation or if some version
@@ -58,7 +58,7 @@ PROJECT_LOGO           =
 # entered, it will be relative to the location where doxygen was started. If
 # left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = apidocs
+OUTPUT_DIRECTORY       = doxygen.build
 
 # If the CREATE_SUBDIRS tag is set to YES then doxygen will create 4096 sub-
 # directories (in 2 levels) under the output directory of each output format and
@@ -829,7 +829,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = "src"
+INPUT                  = "../src"
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
@@ -2039,7 +2039,7 @@ MAN_LINKS              = NO
 # captures the structure of the code including all documentation.
 # The default value is: NO.
 
-GENERATE_XML           = NO
+GENERATE_XML           = YES
 
 # The XML_OUTPUT tag is used to specify where the XML pages will be put. If a
 # relative path is entered the value of OUTPUT_DIRECTORY will be put in front of

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,3 @@
+doxygen.build/
+build/
+.venv

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/build_docs.py
+++ b/docs/build_docs.py
@@ -1,0 +1,80 @@
+from pathlib import Path
+import subprocess
+from contextlib import contextmanager
+from typing import Union
+import os
+import sys
+
+
+DOCS_ROOT = Path(__file__).resolve().parent
+
+
+class CommandNotFoundError(Exception):
+    def __init__(self, command: str):
+        super().__init__(f"command '{command}' not found")
+        self.command = command
+
+
+@contextmanager
+def cwd(path: Union[str, Path]):
+    current_path = Path.cwd()
+
+    if not isinstance(path, Path):
+        path = Path(path)
+    try:
+        os.chdir(path)
+        yield
+    finally:
+        os.chdir(current_path)
+
+
+def run(cmd, **kwargs):
+    if "check" not in kwargs:
+        kwargs["check"] = True
+    print(f"""> {" ".join(cmd)}""")
+    try:
+        return subprocess.run(cmd, **kwargs)
+    except FileNotFoundError as e:
+        raise CommandNotFoundError(cmd[0]) from e
+
+
+def main():
+    if not os.environ.get("VIRTUAL_ENV", ""):
+        print("ERROR> script not running in ")
+    try:
+        import sphinx
+    except ImportError:
+        print("ERROR> 'sphinx' package not found")
+        print("")
+        print("To run this script, set up a virtual environment with all dependencies:")
+        print("-------------------------")
+        print("$ python3 -m venv .venv")
+        print("$ source .venv/bin/activate")
+        print("(.venv) $ pip install -r requirements.txt")
+        print("-------------------------")
+        print("")
+        print("To run the script, enter the virtual environment, then run the script")
+        print("-------------------------")
+        print("$ source .venv/bin/activate")
+        print("(.venv) $ python build_docs.py")
+        sys.exit(1)
+
+    print("generate API docs with doxygen...")
+    print(f"DOCS ROOT: {DOCS_ROOT}")
+
+    with cwd(DOCS_ROOT):
+        try:
+            run(["doxygen", ".doxygen"],
+                cwd=DOCS_ROOT)
+
+            run(["sphinx-build", "-b", "html", "source", "build"])
+        except CommandNotFoundError as e:
+            print(str(e))
+            sys.exit(1)
+        except subprocess.CalledProcessError as e:
+            print("script aborted due to non-zero exit code from program")
+            sys.exit(e.returncode)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,5 @@
+docutils>=0.17.1,<0.18
+breathe>=4.32<=4.4
+kmdo>=0.0.5<0.1
+pydata-sphinx-theme>=0.8,<0.9
+Sphinx>=4.4,<4.5

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,62 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+# import os
+# import sys
+# sys.path.insert(0, os.path.abspath('.'))
+from pathlib import Path
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'FlexAlloc'
+copyright = '2022, Samsung'
+author = 'Adam Manzanares, Jesper Wendel Devantier, Joel Andres Granados'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+    'breathe'
+]
+
+# '/path/to/flexalloc/docs/source/conf.py' -> '/path/to/flexalloc/docs'
+docs_root = Path(__file__).resolve().parent.parent
+
+breathe_projects = {
+    "flexalloc": str(docs_root / "doxygen.build" / "xml")
+}
+breathe_default_project = "flexalloc"
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = []
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'pydata_sphinx_theme'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,20 @@
+.. FlexAlloc documentation master file, created by
+   sphinx-quickstart on Thu Feb  3 13:07:32 2022.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to FlexAlloc's documentation!
+=====================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+.. doxygenindex::
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`


### PR DESCRIPTION
Introducing a way of building and maintaining documentation.

Uses Sphinx (as xNVME does), though using the PyData theme instead.

Uses Github actions to build the documentation, producing a single-commit branch which GH uses for its pages feature (~> you push, the documentation gets built and gets published at https://openmpdk.github.io/FlexAlloc/ ).
