### PR TITLE
Activate ZNS HW testing

### DIFF
--- a/pyflexalloc/flexalloc/xnvme_env.pxd
+++ b/pyflexalloc/flexalloc/xnvme_env.pxd
@@ -76,7 +76,6 @@ cdef extern from "flexalloc_xnvme_env.h" nogil:
     uint32_t fla_xne_dev_lba_nbytes(xnvme_dev *dev)
     int fla_xne_dev_open(const char *dev_uri, xnvme_opts *opts, xnvme_dev **dev)
     void fla_xne_dev_close(xnvme_dev *dev)
-    int fla_xne_dev_sanity_check(const xnvme_dev *dev)
 
 
 cdef class XnvmeDev:

--- a/src/flexalloc_mm.h
+++ b/src/flexalloc_mm.h
@@ -21,9 +21,9 @@
 #define FLA_NAME_SIZE 128
 #define FLA_NAME_SIZE_POOL 112
 
-// -------------------------------
 #define FLA_ROOT_OBJ_NONE UINT64_MAX
 
+#define FLA_MDTS_MIN_NBYTES 512
 
 /// mkfs file system initialization parameters
 struct fla_mkfs_p

--- a/src/flexalloc_xnvme_env.c
+++ b/src/flexalloc_xnvme_env.c
@@ -609,6 +609,13 @@ fla_xne_dev_type(const struct xnvme_dev *dev)
   return geo->type;
 }
 
+uint32_t
+fla_xne_dev_mdts_nbytes(const struct xnvme_dev *dev)
+{
+  struct xnvme_geo const *geo = xnvme_dev_get_geo(dev);
+  return geo->mdts_nbytes;
+}
+
 int
 fla_xne_dev_open(const char *dev_uri, struct xnvme_opts *opts, struct xnvme_dev **dev)
 {
@@ -636,31 +643,4 @@ void
 fla_xne_dev_close(struct xnvme_dev *dev)
 {
   xnvme_dev_close(dev);
-}
-
-int
-fla_xne_dev_sanity_check(struct xnvme_dev const * dev, struct xnvme_dev const *md_dev)
-{
-  int err = 0;
-  struct xnvme_geo const * geo = xnvme_dev_get_geo(dev);
-  struct xnvme_geo const *md_geo = NULL;
-
-  if (md_dev)
-    md_geo = xnvme_dev_get_geo(md_dev);
-
-  /*
-   * xNVMe's linux backend can potentially fallback on an incorrect minimum data transfer
-   * (mdts) value if application is not executed with admin privileges. Check here that we
-   * have an mdts of 512 bytes.
-   */
-  err |= geo->mdts_nbytes <= 512; /* TODO get rid of these magic values */
-  if (md_dev)
-    err |= md_geo->mdts_nbytes <= 512;
-
-  FLA_ERR(err, "The minimum data transfer value of dev or md_dev reported to be less than 512."
-          \
-          " This is most probably due to lack of administrative privileges. you can solve " \
-          " this by running with sudo for example.");
-
-  return err;
 }

--- a/src/flexalloc_xnvme_env.h
+++ b/src/flexalloc_xnvme_env.h
@@ -153,6 +153,9 @@ fla_xne_dev_znd_sect(const struct xnvme_dev *dev);
 enum xnvme_geo_type
 fla_xne_dev_type(const struct xnvme_dev *dev);
 
+uint32_t
+fla_xne_dev_mdts_nbytes(const struct xnvme_dev *dev);
+
 int
 fla_xne_dev_open(const char *dev_uri, struct xnvme_opts *opts, struct xnvme_dev **dev);
 

--- a/tests/flexalloc_tests_common.c
+++ b/tests/flexalloc_tests_common.c
@@ -3,6 +3,7 @@
 // Copyright (C) 2021 Adam Manzanares <a.manzanares@samsung.com>
 
 #define _XOPEN_SOURCE 500
+#include <libxnvme_geo.h>
 #include "tests/flexalloc_tests_common.h"
 #include "flexalloc_xnvme_env.h"
 #include "flexalloc_util.h"
@@ -519,11 +520,10 @@ fla_ut_lpbk_fs_destroy(struct fla_ut_lpbk *lpbk, struct flexalloc *fs)
   return err;
 }
 
-int
-fla_ut_fs_use_device()
+bool
+is_globalenv_set(char const * glb)
 {
-  char *dev_uri = getenv("FLA_TEST_DEV");
-  return dev_uri != NULL;
+  return getenv(glb) != NULL;
 }
 
 int
@@ -531,13 +531,13 @@ fla_ut_dev_init(uint64_t disk_min_blocks, struct fla_ut_dev *dev)
 {
   struct xnvme_dev *xdev;
   int err = 0;
-
-  dev->_dev_uri = getenv("FLA_TEST_DEV");
-  dev->_md_dev_uri = getenv("FLA_MD_DEV");
   dev->_is_zns = 0;
+  dev->_md_dev_uri = NULL;
 
-  if (dev->_dev_uri != NULL)
+  if(is_globalenv_set("FLA_TEST_DEV"))
   {
+    dev->_dev_uri = getenv("FLA_TEST_DEV");
+    dev->_md_dev_uri = getenv("FLA_TEST_MD_DEV");
     dev->_is_loop = 0;
     err = fla_xne_dev_open(dev->_dev_uri, NULL, &xdev);
     if (FLA_ERR(err, "fla_xne_dev_open()"))
@@ -606,6 +606,25 @@ fla_ut_dev_use_device(struct fla_ut_dev *dev)
   return dev->_is_loop;
 }
 
+static int
+fla_t_round_slab_size(struct fla_ut_dev * test_dev, uint32_t * slab_min_blocks)
+{
+  int err = 0;
+  struct xnvme_dev * dev;
+  err = fla_xne_dev_open(test_dev->_dev_uri, NULL, &dev);
+
+  if (fla_xne_dev_type(dev) == XNVME_GEO_ZONED)
+  {
+    uint64_t zsz = fla_xne_dev_znd_sect(dev);
+    uint64_t div_res = *slab_min_blocks % zsz;
+    if (div_res > 0 )
+      *slab_min_blocks += (zsz - div_res);
+  }
+
+  fla_xne_dev_close(dev);
+  return err;
+}
+
 int
 fla_ut_fs_create(uint32_t slab_min_blocks, uint32_t npools,
                  struct fla_ut_dev *dev, struct flexalloc **fs)
@@ -627,6 +646,7 @@ fla_ut_fs_create(uint32_t slab_min_blocks, uint32_t npools,
     }
   }
 
+  fla_t_round_slab_size(dev, &slab_min_blocks);
   mkfs_params.dev_uri = (char *)dev->_dev_uri;
   mkfs_params.md_dev_uri = (char *)dev->_md_dev_uri;
   mkfs_params.slab_nlb = slab_min_blocks;

--- a/tests/flexalloc_tests_common.h
+++ b/tests/flexalloc_tests_common.h
@@ -56,6 +56,9 @@ struct fla_ut_dev
 
 #define FLA_TEST_SKIP_RETCODE 77
 
+bool
+is_globalenv_set(char const * glb);
+
 int
 fla_ut_lpbk_dev_alloc(uint64_t block_size, uint64_t nblocks, struct fla_ut_lpbk **loop);
 


### PR DESCRIPTION
When FLA_TEST_{MD,}_DEV is passed to the testing infra we several test
failing. This fixes those tests and allows FA to be tested on ZNS HW.

1. Rounding slab sizes to zone sizes.
   Some tests just used an arbitrary slab size. This would not be possible
   with ZNS as the slab could not end/start in the middle of a zone. We now
   round up to the nearest zone size in the test infra.

2. When there is a write in the middle of an object which is housed in a
   zone then we should expect a failure instead of expecting the
   read/write to occur flawlessly.

3. Some tests like the slab were removed from running when in ZNS mode.
   as they were incompatible due to the fact that the slab size would be
   automatically rounded up.

Signed-off-by: Joel Granados <j.granados@samsung.com>