### PR TITLE
FLA_ERR now accepts variadic args

### DIFF
--- a/src/flexalloc_util.h
+++ b/src/flexalloc_util.h
@@ -12,6 +12,7 @@
 #include <errno.h>
 #include <stdio.h>
 #include <string.h>
+#include <stdarg.h>
 
 #define FLA_ERR_PRX fprintf(stderr, "flexalloc ERR ");
 
@@ -31,22 +32,27 @@
  * @brief Activates error handling if condition is non zero.
  *
  * @param condition zero means no error
- * @param message The message to use in case there is an error
  * @param f The file name where the error occured
  * @param l The line where the error occurred
- * @return condition is returned when errno is 0, otherwise errno is returned
+ * @param fmt The message to use in case there is an error
+ * @param ... vriadic args for fmt. Can be empty.
+ * @return condition is returned.
  */
 static inline int
-fla_err_fl(const int condition, const char * message, const char * f,
-           const int l )
+fla_err_fl(const int condition, const char * f, const int l, const char * fmt, ...)
 {
   if(condition && condition < 2001)
   {
-    FLA_ERR_PRINTF(" %s(%d) %s\n", f, l, message);
+    FLA_ERR_PRINTF(" %s(%d) ", f, l);
+    va_list arglist;
+    va_start(arglist, fmt);
+    vfprintf(stderr, fmt, arglist);
+    va_end(arglist);
+    fprintf(stderr, "\n");
   }
   return condition;
 }
-#define FLA_ERR(condition, message) fla_err_fl(condition, message, __FILE__, __LINE__)
+#define FLA_ERR(condition, ...) fla_err_fl(condition, __FILE__, __LINE__, __VA_ARGS__)
 
 /**
  * @brief Prints errno message if present.

--- a/src/flexalloc_util.h
+++ b/src/flexalloc_util.h
@@ -14,6 +14,7 @@
 #include <string.h>
 #include <stdarg.h>
 
+#define FLA_ERR_MIN_NOPRINT 2001
 #define FLA_ERR_PRX fprintf(stderr, "flexalloc ERR ");
 
 #define FLA_ERR_PRINT(s)                      \
@@ -41,7 +42,7 @@
 static inline int
 fla_err_fl(const int condition, const char * f, const int l, const char * fmt, ...)
 {
-  if(condition && condition < 2001)
+  if(condition && condition < FLA_ERR_MIN_NOPRINT)
   {
     FLA_ERR_PRINTF(" %s(%d) ", f, l);
     va_list arglist;

--- a/src/flexalloc_xnvme_env.c
+++ b/src/flexalloc_xnvme_env.c
@@ -321,7 +321,9 @@ fla_xne_async_strp_seq_x(struct xnvme_dev *dev, void const *buf, struct fla_strp
   };
 
   if ((err = FLA_ERR(sp->xfer_nbytes % sp->dev_lba_nbytes || sp->xfer_snbytes % sp->dev_lba_nbytes,
-                     "Transfer bytes and start offset must be aligned to block size")))
+                     "Transfer bytes (%"PRIu64") and start offset (%"PRIu64") " \
+                     "must be aligned to block size (%"PRIu32")",
+                     sp->xfer_nbytes, sp->xfer_snbytes, sp->dev_lba_nbytes)))
     goto exit;
 
   /*


### PR DESCRIPTION
FLA_ERR now accepts variadic arguments
Some error messages require a further explanation of how things went wrong.
This patch adds variadic arguments to the FLA_ERR macro so we can add
values of relative variables to the error messages.

Signed-off-by: Joel Granados <j.granados@samsung.com>