### PR TITLE
Add striping daemon & fio engine

### DIFF
--- a/examples/bw_tester/bw_tester.c
+++ b/examples/bw_tester/bw_tester.c
@@ -109,7 +109,7 @@ int main(int argc, char **argv)
     goto close;
   }
 
-  ret = fla_pool_set_strp(fs, pool, strp_nobjs, strp_nbytes);
+  ret = fla_pool_set_strp(fs, pool->ndx, strp_nobjs, strp_nbytes);
   if (ret) {
     printf("Error setting pool strp sz\n");
     goto close;

--- a/fio-ioengine/flexalloc.c
+++ b/fio-ioengine/flexalloc.c
@@ -29,6 +29,8 @@ struct flexalloc_options {
 	char *dev_uri;
 	char *md_dev_uri;
 	char *poolname;
+	int strp_nobj;
+	int strp_nbyte;
 };
 
 struct fio_option fa_options[] = {
@@ -70,6 +72,24 @@ struct fio_option fa_options[] = {
 		.off1		= offsetof(struct flexalloc_options, poolname),
 		.category	= FIO_OPT_C_ENGINE,
 		.group		= FIO_OPT_G_FILENAME,
+	},
+	{
+		.name		= "strp_nobj",
+		.lname		= "Number of FLA objects in striped object",
+		.type		= FIO_OPT_INT,
+		.help		= "Number of FLA objects in striped object",
+		.off1		= offsetof(struct flexalloc_options, strp_nobj),
+		.category	= FIO_OPT_C_ENGINE,
+		.group		= FIO_OPT_G_INVALID,
+	},
+	{
+		.name		= "strp_nbyte",
+		.lname		= "Stripe size within fla object",
+		.type		= FIO_OPT_INT,
+		.help		= "Stripe size within fla object",
+		.off1		= offsetof(struct flexalloc_options, strp_nbyte),
+		.category	= FIO_OPT_C_ENGINE,
+		.group		= FIO_OPT_G_INVALID,
 	},
 	{
 		.name	= NULL,
@@ -363,6 +383,15 @@ static int fio_flexalloc_init(struct thread_data *td)
 	if (ret) {
 		log_err("flexalloc: error creating pool %s\n", pool_name);
 		goto done;
+	}
+
+	if(o->strp_nobj && o->strp_nbyte) {
+		ret = fla_pool_set_strp(fad->fs, fad->pool, o->strp_nobj, o->strp_nbyte);
+		if (ret) {
+			log_err("Could not stripe the pool strp_nobj : %d, strp_nbyte : %d", 
+					o->strp_nobj, o->strp_nbyte);
+			goto done;
+		}
 	}
 
 	dprint(FD_FILE, "flexalloc: created pool %p with poolname %s\n", &fad->pool, pool_name);

--- a/src/flexalloc_daemon.c
+++ b/src/flexalloc_daemon.c
@@ -81,8 +81,12 @@ msg_handler(struct fla_daemon *d, int client_fd, struct fla_msg const * const re
       return -1;
     break;
   case FLA_MSG_CMD_INIT_INFO:
-    FLA_DBG_PRINT("FLA_MSG_CMD_INIT_INFO\n");
     if (FLA_ERR(fla_daemon_fs_init_rsp(d, client_fd, recv, send), "fla_daemon_init_info()"))
+      return -1;
+    break;
+  case FLA_MSG_CMD_POOL_SET_STRP:
+    if(FLA_ERR(fla_daemon_pool_set_strp_rsp(d, client_fd, recv, send),
+               "fla_daemon_pool_set_strp_rsp()"))
       return -1;
     break;
   default:

--- a/src/flexalloc_daemon_base.h
+++ b/src/flexalloc_daemon_base.h
@@ -42,6 +42,7 @@ struct fla_msg
 #define FLA_MSG_CMD_POOL_OPEN 3
 #define FLA_MSG_CMD_POOL_CLOSE 4
 #define FLA_MSG_CMD_POOL_CREATE 5
+#define FLA_MSG_CMD_POOL_SET_STRP 13
 #define FLA_MSG_CMD_POOL_DESTROY 6
 #define FLA_MSG_CMD_POOL_SET_ROOT_OBJECT 7
 #define FLA_MSG_CMD_POOL_GET_ROOT_OBJECT 8
@@ -305,6 +306,15 @@ fla_daemon_pool_get_root_object_rsp(struct fla_daemon *daemon, int client_fd,
 int
 fla_daemon_open(const char * socket_path, struct fla_daemon_client * client);
 
+
+int
+fla_daemon_pool_set_strp_rq(struct flexalloc *fs, struct fla_pool *pool, uint32_t strp_nobjs,
+                            uint32_t strp_nbytes);
+
+int
+fla_daemon_pool_set_strp_rsp(struct fla_daemon *daemon, int client_fd,
+                             struct fla_msg const * const recv,
+                             struct fla_msg const * const send);
 #ifdef __cplusplus
 }
 #endif

--- a/src/flexalloc_mm.c
+++ b/src/flexalloc_mm.c
@@ -833,10 +833,10 @@ fla_pool_entry_reset(struct fla_pool_entry *pool_entry, const char *name, int na
 }
 
 int
-fla_pool_set_strp(struct flexalloc *fs, struct fla_pool *ph, uint32_t strp_nobjs,
-                  uint32_t strp_nbytes)
+fla_base_pool_set_strp(struct flexalloc *fs, struct fla_pool *pool, uint32_t strp_nobjs,
+                       uint32_t strp_nbytes)
 {
-  struct fla_pool_entry *pool_entry = &fs->pools.entries[ph->ndx];
+  struct fla_pool_entry *pool_entry = &fs->pools.entries[pool->ndx];
   const struct xnvme_geo * geo = xnvme_dev_get_geo(fs->dev.dev);
 
   if (FLA_ERR(strp_nbytes > geo->mdts_nbytes, "Strp sz > mdts for device"))
@@ -1454,7 +1454,7 @@ fla_object_write(struct flexalloc * fs, struct fla_pool const * pool_handle,
     fla_znd_manage_zones(fs, obj_zn);
 
   slab_eoffset = (fla_geo_slab_lb_off(fs, obj->slab_id) + fs->geo.slab_nlb) * fs->geo.lb_nbytes;
-  if((err = FLA_ERR(slab_eoffset < obj_eoffset, "Write outside a slab")))
+  if((err = FLA_ERR(slab_eoffset < obj_eoffset, "Write outside slab")))
     goto exit;
 
   if((err = FLA_ERR(obj_eoffset < w_eoffset, "Write outside of an object")))
@@ -1641,6 +1641,7 @@ struct fla_fns base_fns =
   .pool_close = &fla_base_pool_close,
   .pool_create = &fla_base_pool_create,
   .pool_destroy = &fla_base_pool_destroy,
+  .pool_set_strp = &fla_base_pool_set_strp,
   .object_open = &fla_base_object_open,
   .object_create = &fla_base_object_create,
   .object_destroy = &fla_base_object_destroy,

--- a/src/flexalloc_shared.h
+++ b/src/flexalloc_shared.h
@@ -76,6 +76,8 @@ struct fla_fns
   int (*pool_create)(struct flexalloc *fs, const char *name, int name_len, uint32_t obj_nlb,
                      struct fla_pool **pool);
   int (*pool_destroy)(struct flexalloc *fs, struct fla_pool *pool);
+  int (*pool_set_strp)(struct flexalloc *fs, struct fla_pool *pool, uint32_t strp_nobjs,
+                       uint32_t strp_nbytes);
   int (*object_open)(struct flexalloc *fs, struct fla_pool *pool, struct fla_object *object);
   int (*object_create)(struct flexalloc *fs, struct fla_pool *pool, struct fla_object *object);
   int (*object_destroy)(struct flexalloc *fs, struct fla_pool *pool, struct fla_object *object);

--- a/src/libflexalloc.c
+++ b/src/libflexalloc.c
@@ -90,3 +90,10 @@ fla_pool_get_root_object(struct flexalloc const * const fs,
 {
   return fs->fns.pool_get_root_object(fs, pool, object);
 }
+
+int
+fla_pool_set_strp(struct flexalloc *fs, struct fla_pool *pool, uint32_t strp_nobjs,
+                  uint32_t strp_nbytes)
+{
+  return fs->fns.pool_set_strp(fs, pool, strp_nobjs, strp_nbytes);
+}

--- a/src/libflexalloc.h
+++ b/src/libflexalloc.h
@@ -300,7 +300,7 @@ fla_object_seal(struct flexalloc *fs, struct fla_pool const *pool_handle, struct
  * @return int indicating if pool striping parameters were applied
  */
 int
-fla_pool_set_strp(struct flexalloc *fs, struct fla_pool const *pool_handle, uint32_t strp_nobjs,
+fla_pool_set_strp(struct flexalloc *fs, struct fla_pool *pool, uint32_t strp_nobjs,
                   uint32_t strp_nbytes);
 
 #ifdef __cplusplus


### PR DESCRIPTION
* Add strp_nobj and strp_nbyte to the fio engine
* Create relevant rq and rsp functions for the daemon
* Create FLA_MSG_CMD_POOL_SET_STRP to handle striping messages in daemon
* Rename fla_pool_set_strp to fla_base_pool_set_strp
* fla_base_pool_set_strp now requires a pool index instead of a pool
  handle.

Signed-off-by: Joel Granados <j.granados@samsung.com>