### PR TITLE
test: Generalize test by setting values in percentages

### DIFF
--- a/tests/flexalloc_rt_strp_object_read_write.c
+++ b/tests/flexalloc_rt_strp_object_read_write.c
@@ -60,6 +60,10 @@ test_strp(struct test_vals test_vals)
   if (FLA_ERR(err, "fla_ut_dev_init()"))
     goto exit;
 
+  // Ignore test with real devices
+  if(test_vals.blk_num != dev.nblocks)
+    goto teardown_ut_dev;
+
   if (dev._is_zns)
   {
     // why *2? -> To run these tests we need at least one striped object. The

--- a/tests/flexalloc_ut_slab.c
+++ b/tests/flexalloc_ut_slab.c
@@ -69,16 +69,6 @@ test_slabs(struct test_vals * test_vals)
   if(dev._is_zns)
     goto exit;
 
-  /* Skip real devs
-   * The way we test slabs requires us to create slab sizes of 2 lbs
-   * For devices with lots of lbs, it takes too long. Skip it while
-   * we come up with a better way of doing things.
-   * if(test_vals->disk_min_lbs == 0)
-   *   test_vals->disk_min_lbs = dev.nblocks;
-   */
-  if(test_vals->disk_min_lbs != dev.nblocks)
-    goto exit;
-
   slab_error = malloc(sizeof(struct fla_slab_header));
   if (FLA_ERR(!slab_error, "malloc()"))
   {

--- a/tests/flexalloc_ut_slab.c
+++ b/tests/flexalloc_ut_slab.c
@@ -8,33 +8,34 @@
 struct test_vals
 {
   uint32_t npools;
-  uint32_t slab_nlb;
-  uint32_t disk_min_lbs;
-  uint32_t obj_nlb;
+  uint32_t min_disk_lbs; // Will be overridden by real size on "real" HW.
+  float slab_size_p; // slab size in percent of disk size
+  float obj_size_p; // obje size in percent of slab size
 };
 
 static int test_slabs(struct test_vals * test_vals);
 static int test_check_slab_pointers(struct flexalloc * fs, const uint32_t expected_size);
 
-#define FLA_UT_SLAB_NUMBER_OF_TESTS 4
-
 int
 main(int argc, char ** argv)
 {
   int err = 0;
-  bool fla_test_set = is_globalenv_set("FLA_TEST_DEV");
-  struct test_vals test_vals [FLA_UT_SLAB_NUMBER_OF_TESTS] =
+
+  struct test_vals test_vals [] =
   {
-    {.npools = 2, .slab_nlb = 2, .disk_min_lbs = 9, .obj_nlb = 1 }
-    , {.npools = 2, .slab_nlb = 2, .disk_min_lbs = 21, .obj_nlb = 1 }
-    , {.npools = 2, .slab_nlb = 20, .disk_min_lbs = 50, .obj_nlb = 2 }
-    , {.npools = 2, .slab_nlb = 5, .disk_min_lbs = 18, .obj_nlb = 1 }
+    {.npools = 1, .min_disk_lbs = 100, .slab_size_p = 0.8, .obj_size_p = 0.8 }
+    , {.npools = 1, .min_disk_lbs = 100, .slab_size_p = 0.8, .obj_size_p = 0.2 }
+    , {.npools = 2, .min_disk_lbs = 100, .slab_size_p = 0.4, .obj_size_p = 0.8 }
+    , {.npools = 2, .min_disk_lbs = 100, .slab_size_p = 0.4, .obj_size_p = 0.2 }
+    , {.npools = 4, .min_disk_lbs = 100, .slab_size_p = 0.2, .obj_size_p = 0.8 }
+    , {.npools = 4, .min_disk_lbs = 100, .slab_size_p = 0.2, .obj_size_p = 0.2 }
+    , {.npools = 0, .min_disk_lbs = 0, .slab_size_p = 0, .obj_size_p = 0}
   };
 
-  for(int i = 0 ; i < FLA_UT_SLAB_NUMBER_OF_TESTS ; ++i)
+  for(int i = 0 ; true ; ++i)
   {
-    if(fla_test_set)
-      test_vals[i].disk_min_lbs = 0;
+    if (test_vals[i].npools == 0)
+      goto exit;
     err = test_slabs(&test_vals[i]);
     if(FLA_ERR(err, "test_slabs()"))
     {
@@ -53,14 +54,14 @@ test_slabs(struct test_vals * test_vals)
   struct fla_ut_dev dev;
   struct flexalloc *fs;
   struct fla_slab_header *slab_header, *slab_error;
-  uint64_t available_lb_for_slabs;
-  uint32_t expected_slabs;
+  uint32_t slab_nlb, obj_nlb, init_free_slabs;
 
-  err = fla_ut_dev_init(test_vals->disk_min_lbs, &dev);
+  err = fla_ut_dev_init(test_vals->min_disk_lbs, &dev);
   if (FLA_ERR(err, "fla_ut_dev_init()"))
   {
     goto exit;
   }
+  test_vals->min_disk_lbs = dev.nblocks;
 
   /* Skip for ZNS.
    * If we are testing ZNS, we will automatically modify slab size
@@ -76,36 +77,34 @@ test_slabs(struct test_vals * test_vals)
     goto exit;
   }
 
-  err = fla_ut_fs_create(test_vals->slab_nlb, test_vals->npools, &dev, &fs);
+  slab_nlb = (uint32_t)(test_vals->min_disk_lbs * test_vals->slab_size_p);
+  obj_nlb = (uint32_t)(slab_nlb * test_vals->obj_size_p);
+
+  err = fla_ut_fs_create(slab_nlb, test_vals->npools, &dev, &fs);
   if (FLA_ERR(err, "fla_ut_fs_create()"))
   {
     goto free_slab_error;
   }
 
-  FLA_ASSERTF(test_vals->disk_min_lbs > fla_geo_slabs_lb_off(&fs->geo),
+  init_free_slabs = *fs->slabs.fslab_num;
+
+  FLA_ASSERTF(test_vals->min_disk_lbs > fla_geo_slabs_lb_off(&fs->geo),
               "Slabs start after disk has ended (%"PRIu64" > %"PRIu64"",
-              test_vals->disk_min_lbs, fla_geo_slabs_lb_off(&fs->geo));
-  available_lb_for_slabs = test_vals->disk_min_lbs - fla_geo_slabs_lb_off(&fs->geo);
-  expected_slabs = available_lb_for_slabs / test_vals->slab_nlb;
+              test_vals->min_disk_lbs, fla_geo_slabs_lb_off(&fs->geo));
 
-  /* Test values in struct fla_slabs */
-  err |= FLA_ASSERTF(*fs->slabs.fslab_num == expected_slabs,
-                     "Unexpected number of free slabs (%d == %d)",
-                     *fs->slabs.fslab_num, expected_slabs);
+  /* we need at least one slab */
+  err |= FLA_ASSERTF(init_free_slabs >= 1, "Unexpected number of free slabs (%d >= 1)",
+                     init_free_slabs);
 
-  /*err |= FLA_ASSERTF(*fs->slabs.fslab_head == 0,
-                     "Unexpected head ID (%d == %d)", *fs->slabs.fslab_head, 0);*/
-
-  err |= FLA_ASSERTF(*fs->slabs.fslab_tail == expected_slabs - 1,
-                     "Unexpected tail ID (%d == %d)",
-                     *fs->slabs.fslab_tail, expected_slabs - 1);
+  err |= FLA_ASSERTF(*fs->slabs.fslab_head == 0,
+                     "Unexpected head ID (%d == %d)", *fs->slabs.fslab_head, 0);
 
   /* Acquire all the slabs and then release them all */
-  for(uint32_t slab_offset = 0 ; slab_offset < expected_slabs ; ++slab_offset)
+  for(uint32_t slab_offset = 0 ; slab_offset < init_free_slabs ; ++slab_offset)
   {
     slab_header = (void*)fs->slabs.headers + (slab_offset * sizeof(struct fla_slab_header));
 
-    err = fla_acquire_slab(fs, test_vals->obj_nlb, &slab_header);
+    err = fla_acquire_slab(fs, obj_nlb, &slab_header);
     if(FLA_ERR(err, "fla_acquire_slab()"))
     {
       goto close_fs;
@@ -120,16 +119,16 @@ test_slabs(struct test_vals * test_vals)
       goto close_fs;
     }
 
-    const uint32_t free_slabs = expected_slabs - (slab_offset + 1);
-    err = FLA_ASSERTF(*fs->slabs.fslab_num == free_slabs,
-                      "Unexpected number of free slabs (%d == %d)",
-                      *fs->slabs.fslab_num, free_slabs);
+    const uint32_t curr_free_slabs = init_free_slabs - (slab_offset + 1);
+    err = FLA_ASSERTF(*fs->slabs.fslab_num >= curr_free_slabs,
+                      "Unexpected number of free slabs (%d >= %d)",
+                      *fs->slabs.fslab_num, curr_free_slabs);
     if(FLA_ERR(err, "FLA_ASSERTF()"))
     {
       goto close_fs;
     }
 
-    err = test_check_slab_pointers(fs, free_slabs);
+    err = test_check_slab_pointers(fs, curr_free_slabs);
     if(FLA_ERR(err, "test_check_slab_pointers()"))
     {
       goto close_fs;
@@ -137,14 +136,14 @@ test_slabs(struct test_vals * test_vals)
   }
 
   /* If we acquire another slab, we should receive an error */
-  ret = fla_acquire_slab(fs, test_vals->obj_nlb, &slab_error);
+  ret = fla_acquire_slab(fs, obj_nlb, &slab_error);
   err = FLA_ASSERT(ret != 0, "Acquire of an empty free list did NOT fail");
   if(FLA_ERR(err, "FLA_ASSERT()"))
   {
     goto close_fs;
   }
 
-  for(uint32_t slab_offset = 0 ; slab_offset < expected_slabs ; ++slab_offset)
+  for(uint32_t slab_offset = 0 ; slab_offset < init_free_slabs ; ++slab_offset)
   {
     slab_header = (void*)fs->slabs.headers + (slab_offset * sizeof(struct fla_slab_header));
 
@@ -152,8 +151,8 @@ test_slabs(struct test_vals * test_vals)
     if(FLA_ERR(err, "fla_release_slab()"))
       goto close_fs;
 
-    err = FLA_ASSERTF(*fs->slabs.fslab_num == slab_offset + 1,
-                      "Unexpected number of free slabs (%d == %d)",
+    err = FLA_ASSERTF(*fs->slabs.fslab_num >= slab_offset + 1,
+                      "Unexpected number of free slabs (%d >= %d)",
                       *fs->slabs.fslab_num, slab_offset + 1);
     if(FLA_ERR(err, "FLA_ASSERTF()"))
       goto close_fs;
@@ -174,7 +173,7 @@ exit:
 }
 
 int
-test_check_slab_pointers(struct flexalloc * fs, const uint32_t expected_size)
+test_check_slab_pointers(struct flexalloc * fs, const uint32_t curr_free_slabs)
 {
   int err = 0;
   struct fla_slab_header * curr_slab;
@@ -182,7 +181,7 @@ test_check_slab_pointers(struct flexalloc * fs, const uint32_t expected_size)
 
   /* check next pointers */
   curr_slab_id = *fs->slabs.fslab_head;
-  for (uint32_t i = 0 ; i <= expected_size && curr_slab_id != INT32_MAX; ++i)
+  for (uint32_t i = 0 ; i <= curr_free_slabs && curr_slab_id != INT32_MAX; ++i)
   {
     curr_slab = fla_slab_header_ptr(curr_slab_id, fs);
     if((err = -FLA_ERR(!curr_slab, "fla_slab_header_ptr()")))
@@ -193,13 +192,13 @@ test_check_slab_pointers(struct flexalloc * fs, const uint32_t expected_size)
     size_from_head++;
   }
 
-  err = FLA_ASSERTF(size_from_head == expected_size,
+  err = FLA_ASSERTF(size_from_head >= curr_free_slabs,
                     "Unexpected size when starting from head (%d == %d)",
-                    size_from_head, expected_size);
+                    size_from_head, curr_free_slabs);
 
   /* check prev pointers */
   curr_slab_id = *fs->slabs.fslab_tail;
-  for (uint32_t i = 0; i <= expected_size && curr_slab_id != INT32_MAX; ++i)
+  for (uint32_t i = 0; i <= curr_free_slabs && curr_slab_id != INT32_MAX; ++i)
   {
     curr_slab = fla_slab_header_ptr(curr_slab_id, fs);
     if((err = -FLA_ERR(!curr_slab, "fla_slab_header_ptr()")))


### PR DESCRIPTION
We were ignoring "real"devices in the  slab test because it was not designed for big lb ranges.
We update the slab tests so it calculates tests parameters in terms of percentages rather than hard lb numbers. Tested in ZNS, CNS and loop.
Signed-off-by: Joel Granados <j.granados@samsung.com>