### PR TITLE
Compound PR with various changes

### DIFF
--- a/examples/bw_tester/bw_tester.c
+++ b/examples/bw_tester/bw_tester.c
@@ -132,6 +132,10 @@ int main(int argc, char **argv)
     ret = r_w_obj(fs, pool, &obj, num_writes, wrt_nbytes, false, verify, rand_num);
     if(ret)
       goto close;
+
+    ret = fla_object_close(fs , pool, &obj);
+    if(ret)
+      goto close;
   }
 
 close:

--- a/examples/bw_tester/bw_tester.c
+++ b/examples/bw_tester/bw_tester.c
@@ -133,7 +133,7 @@ int main(int argc, char **argv)
     if(ret)
       goto close;
 
-    ret = fla_object_close(fs , pool, &obj);
+    ret = fla_object_seal(fs , pool, &obj);
     if(ret)
       goto close;
   }

--- a/src/flexalloc.h
+++ b/src/flexalloc.h
@@ -15,14 +15,6 @@
 #include "flexalloc_freelist.h"
 #include "flexalloc_hash.h"
 
-struct fla_zs_entry
-{
-  int zone_number;
-  TAILQ_ENTRY(fla_zs_entry) entries;
-};
-
-TAILQ_HEAD(zs_thead, fla_zs_entry);
-
 /// flexalloc device handle
 struct fla_dev
 {
@@ -125,8 +117,6 @@ struct flexalloc
   struct fla_super *super;
   struct fla_pools pools;
   struct fla_slabs slabs;
-  struct zs_thead zs_thead;
-  uint32_t zs_size;
 
   struct fla_fns fns;
 

--- a/src/flexalloc_freelist.c
+++ b/src/flexalloc_freelist.c
@@ -150,3 +150,14 @@ fla_flist_entry_free(freelist_t flist, uint32_t ndx)
   *elem |= 1 << ndx;
   return 0;
 }
+
+int
+fla_flist_entries_free(freelist_t flist, uint32_t ndx, unsigned int num)
+{
+  for(uint32_t i = 0 ; i < num ; ++i)
+  {
+    if(fla_flist_entry_free(flist, ndx+i))
+      return -1;
+  }
+  return 0;
+}

--- a/src/flexalloc_freelist.c
+++ b/src/flexalloc_freelist.c
@@ -142,7 +142,7 @@ fla_flist_entry_free(freelist_t flist, uint32_t ndx)
   if (ndx > *flist)
     return -1;
 
-  while (ndx > sizeof(uint32_t) * CHAR_BIT)
+  while (ndx >= sizeof(uint32_t) * CHAR_BIT)
   {
     elem++;
     ndx -= sizeof(uint32_t) * CHAR_BIT;

--- a/src/flexalloc_freelist.h
+++ b/src/flexalloc_freelist.h
@@ -146,4 +146,8 @@ fla_flist_entries_alloc(freelist_t flist, unsigned int num);
 int
 fla_flist_entry_free(freelist_t flist, uint32_t ndx);
 
+
+int
+fla_flist_entries_free(freelist_t flist, uint32_t ndx, unsigned int num);
+
 #endif // __FLEXALLOC_FREELIST_H_

--- a/src/flexalloc_mm.c
+++ b/src/flexalloc_mm.c
@@ -1649,7 +1649,7 @@ struct fla_fns base_fns =
 };
 
 int
-fla_object_close(struct flexalloc *fs, struct fla_pool const *pool_handle, struct fla_object *obj)
+fla_object_seal(struct flexalloc *fs, struct fla_pool const *pool_handle, struct fla_object *obj)
 {
   int err = 0;
 

--- a/src/flexalloc_mm.c
+++ b/src/flexalloc_mm.c
@@ -58,28 +58,31 @@ fla_dev_sanity_check(struct xnvme_dev const * dev, struct xnvme_dev const *md_de
 }
 
 void
-print_slab_sgmt(const struct flexalloc * fs)
+print_slab_sgmt(const struct flexalloc * fs, uint32_t from , uint32_t to)
 {
   struct fla_slab_header * slab;
 
   fprintf(stderr, "%s\n", "--------------------------------");
-  fprintf(stderr, "Slabs number : %d\n", *fs->slabs.fslab_num);
-  fprintf(stderr, "Slabs head : %d\n", *fs->slabs.fslab_head);
-  fprintf(stderr, "Slabs tail : %d\n", *fs->slabs.fslab_tail);
+  fprintf(stderr, "Slabs number : %"PRIu32"\n", *fs->slabs.fslab_num);
+  fprintf(stderr, "Slabs head : %"PRIu32"\n", *fs->slabs.fslab_head);
+  fprintf(stderr, "Slabs tail : %"PRIu32"\n", *fs->slabs.fslab_tail);
   fprintf(stderr, "Header ptr : %p\n", fs->slabs.headers);
 
-  /*for(int i = 0 ; i < 1024 ; ++i)
-  {
-    fprintf(stderr, "%0x", (char)*((char*)fs->slabs.headers + i));
-  }
-  fprintf(stderr, "\n");*/
+  if (to == 0)
+    to = fs->geo.nslabs;
 
-  for(uint32_t i = 0 ; i < fs->geo.nslabs ; ++i)
+  if (from >= to)
+  {
+    fprintf(stderr, "from (%"PRIu32") is greater than to (%"PRIu32")\n", from, to);
+    return;
+  }
+
+  for(uint32_t i = from ; i < to ; ++i)
   {
     slab = fs->slabs.headers + i;
-    fprintf(stderr, "slab number %d\n", i);
-    fprintf(stderr, "next : %d\n", slab->next);
-    fprintf(stderr, "prev : %d\n", slab->prev);
+    fprintf(stderr, "slab number %"PRIu32", ", i);
+    fprintf(stderr, "next : %"PRIu32", ", slab->next);
+    fprintf(stderr, "prev : %"PRIu32"\n", slab->prev);
   }
   fprintf(stderr, "%s\n", "--------------------------------");
 

--- a/src/flexalloc_mm.c
+++ b/src/flexalloc_mm.c
@@ -371,16 +371,15 @@ fla_geo_slabs_lb_off(struct fla_geo const *geo)
 uint64_t
 fla_geo_slab_lb_off(struct flexalloc const *fs, uint32_t slab_id)
 {
-  uint64_t slabs_base = fla_geo_slabs_lb_off(&fs->geo);
-  uint64_t slab_base;
+  uint64_t slabs_base = 0, slab_base;
 
-  if (fs->dev.md_dev)
-    slabs_base = 0;
+  if (fs->dev.md_dev == NULL)
+    slabs_base = fla_geo_slabs_lb_off(&fs->geo);
 
   slab_base = slabs_base + (slab_id * fs->geo.slab_nlb);
   if (fla_geo_zoned(&fs->geo) && slab_base % fs->geo.nzsect)
   {
-    slab_base += fs->geo.nzsect - slabs_base;
+    slab_base += (slab_base % fs->geo.nzsect);
   }
 
   return slab_base;

--- a/src/flexalloc_shared.h
+++ b/src/flexalloc_shared.h
@@ -85,6 +85,7 @@ struct fla_fns
                               struct fla_object const *object, fla_root_object_set_action act);
   int (*pool_get_root_object)(struct flexalloc const * const fs, struct fla_pool const * pool,
                               struct fla_object *object);
+  int (*fla_action)();
 };
 
 struct flexalloc *
@@ -98,7 +99,6 @@ fla_fs_set_user(void *user_data);
 
 void *
 fla_fs_get_user();
-
 
 #ifdef __cplusplus
 }

--- a/src/flexalloc_slabcache.c
+++ b/src/flexalloc_slabcache.c
@@ -235,7 +235,7 @@ fla_slab_cache_obj_alloc(struct fla_slab_flist_cache *cache, uint32_t slab_id,
 
 int
 fla_slab_cache_obj_free(struct fla_slab_flist_cache *cache,
-                        struct fla_object * obj_id)
+                        struct fla_object * obj_id, uint32_t num_objs)
 {
   struct fla_slab_flist_cache_elem *e = &cache->_head[obj_id->slab_id];
   int err;
@@ -243,8 +243,8 @@ fla_slab_cache_obj_free(struct fla_slab_flist_cache *cache,
   if (e->state == FLA_SLAB_CACHE_ELEM_STALE)
     return FLA_SLAB_CACHE_INVALID_STATE;
 
-  err = fla_flist_entry_free(e->freelist, obj_id->entry_ndx);
-  if (FLA_ERR(err, "fla_flist_entry_free() - failed to free object in freelist"))
+  err = fla_flist_entries_free(e->freelist, obj_id->entry_ndx, num_objs);
+  if (FLA_ERR(err, "fla_flist_entries_free() - failed to free object in freelist"))
     goto exit;
 
   e->state = FLA_SLAB_CACHE_ELEM_DIRTY;

--- a/src/flexalloc_slabcache.h
+++ b/src/flexalloc_slabcache.h
@@ -193,12 +193,13 @@ fla_slab_cache_obj_alloc(struct fla_slab_flist_cache *cache, uint32_t slab_id,
  *
  * @param cache slab freelist cache
  * @param obj_id object id, uniquely identifying the object and its parent slab
+ * @param strp_nobjs Number of objects to stripe accross
  *
  * @return On success 0, otherwise an error occurred and the entry was not freed.
  */
 int
 fla_slab_cache_obj_free(struct fla_slab_flist_cache *cache,
-                        struct fla_object * obj_id);
+                        struct fla_object * obj_id, uint32_t strp_nobjs);
 
 /**
  * Flush all dirty cache entries to disk.

--- a/src/flexalloc_znd.c
+++ b/src/flexalloc_znd.c
@@ -14,11 +14,10 @@ fla_znd_manage_zones_object_finish(struct flexalloc *fs, struct fla_pool const *
 
   for (uint32_t strp = 0; strp < pool_entry->strp_nobjs; strp++)
   {
-    err = fla_xne_dev_znd_send_mgmt(fs->dev.dev, obj_slba + (fs->geo.nzsect * strp),
-                                    XNVME_SPEC_ZND_CMD_MGMT_SEND_FINISH, false);
-    if (FLA_ERR(err, "fla_xne_dev_znd_send_mgmt_finish()"))
-      return err;
+    err |= fla_xne_dev_znd_send_mgmt(fs->dev.dev, obj_slba + (fs->geo.nzsect * strp),
+                                     XNVME_SPEC_ZND_CMD_MGMT_SEND_FINISH, false);
   }
+  FLA_ERR(err, "fla_xne_dev_znd_send_mgmt_finish()");
   return err;
 }
 
@@ -32,12 +31,10 @@ fla_znd_manage_zones_object_reset(struct flexalloc *fs, struct fla_pool const *p
 
   for (uint32_t strp = 0; strp < pool_entry->strp_nobjs; strp++)
   {
-
-    err = fla_xne_dev_znd_send_mgmt(fs->dev.dev, obj_slba + (fs->geo.nzsect * strp),
-                                    XNVME_SPEC_ZND_CMD_MGMT_SEND_RESET, false);
-    if (FLA_ERR(err, "fla_xne_dev_znd_send_mgmt_reset()"))
-      return err;
+    err |= fla_xne_dev_znd_send_mgmt(fs->dev.dev, obj_slba + (fs->geo.nzsect * strp),
+                                     XNVME_SPEC_ZND_CMD_MGMT_SEND_RESET, false);
   }
+  FLA_ERR(err, "fla_xne_dev_znd_send_mgmt_reset()");
   return err;
 }
 

--- a/src/flexalloc_znd.c
+++ b/src/flexalloc_znd.c
@@ -4,103 +4,40 @@
 #include "flexalloc_mm.h"
 #include "flexalloc_util.h"
 
-// Full zones are implicitly placed into the closed state so no need to manage anymore
-void
-fla_znd_zone_full(struct flexalloc *fs, uint32_t zone)
+int
+fla_znd_manage_zones_object_finish(struct flexalloc *fs, struct fla_pool const *pool_handle,
+                                   struct fla_object *obj)
 {
-  struct fla_zs_entry *z_entry;
-
-  TAILQ_FOREACH(z_entry, &fs->zs_thead, entries)
-  {
-    if (z_entry->zone_number == zone)
-      break;
-  }
-
-  // We should probably warn here
-  if (!z_entry)
-    return;
-
-  TAILQ_REMOVE(&fs->zs_thead, z_entry, entries);
-  fs->zs_size--;
-}
-
-void
-fla_znd_manage_zones_cleanup(struct flexalloc *fs)
-{
-  struct fla_zs_entry *z_entry;
-
-  while ((z_entry = TAILQ_FIRST(&fs->zs_thead)))
-  {
-    TAILQ_REMOVE(&fs->zs_thead, z_entry, entries);
-    free(z_entry);
-  }
-}
-
-void
-fla_znd_manage_zones(struct flexalloc *fs, uint32_t zone)
-{
-
-  struct fla_zs_entry *z_entry;
-  uint64_t zlba;
-  int ret;
-
-  TAILQ_FOREACH(z_entry, &fs->zs_thead, entries)
-  {
-    if (z_entry->zone_number == zone)
-      break;
-  }
-
-  if (z_entry)
-  {
-    // We found the entry so remove and reinsert at head
-    TAILQ_REMOVE(&fs->zs_thead, z_entry, entries);
-    TAILQ_INSERT_HEAD(&fs->zs_thead, z_entry, entries);
-    return;
-  }
-
-  // We are under the number of zones limit
-  if (fs->zs_size < fla_xne_dev_get_znd_mor(fs->dev.dev))
-  {
-    z_entry = malloc(sizeof(struct fla_zs_entry));
-    assert(z_entry);
-    z_entry->zone_number = zone;
-    TAILQ_INSERT_HEAD(&fs->zs_thead, z_entry, entries);
-    fs->zs_size++;
-  }
-  else // We have to close a zone
-  {
-    z_entry = TAILQ_LAST(&fs->zs_thead, zs_thead);
-    assert(z_entry);
-    zlba = z_entry->zone_number * fs->geo.nzsect;
-    ret = fla_xne_dev_znd_send_mgmt(fs->dev.dev, zlba, XNVME_SPEC_ZND_CMD_MGMT_SEND_CLOSE, false);
-    if (ret)
-      FLA_ERR_PRINTF("Error trying to close zone at:%lu\n", zlba);
-
-    z_entry->zone_number = zone;
-    TAILQ_REMOVE(&fs->zs_thead, z_entry, entries);
-    TAILQ_INSERT_HEAD(&fs->zs_thead, z_entry, entries);
-  }
-}
-
-bool
-fla_object_seal(struct flexalloc *fs, struct fla_pool const *pool_handle, struct fla_object *obj)
-{
-
+  int err = 0;
   uint64_t obj_slba = fla_object_slba(fs, obj, pool_handle);
-  uint32_t obj_zn = obj_slba / fs->geo.nzsect;
   struct fla_pool_entry *pool_entry = &fs->pools.entries[pool_handle->ndx];
-  uint32_t strps = pool_entry->strp_nobjs;
 
-  for (uint32_t strp = 0; strp < strps; strp++)
+  for (uint32_t strp = 0; strp < pool_entry->strp_nobjs; strp++)
   {
-    int err = fla_xne_dev_znd_send_mgmt(fs->dev.dev, obj_slba + (fs->geo.nzsect * strp),
-                                        XNVME_SPEC_ZND_CMD_MGMT_SEND_FINISH, false);
+    err = fla_xne_dev_znd_send_mgmt(fs->dev.dev, obj_slba + (fs->geo.nzsect * strp),
+                                    XNVME_SPEC_ZND_CMD_MGMT_SEND_FINISH, false);
     if (FLA_ERR(err, "fla_xne_dev_znd_send_mgmt_finish()"))
-      return false;
+      return err;
   }
+  return err;
+}
 
-  // Update me for striping
-  fla_znd_zone_full(fs, obj_zn);
-  return true;
+int
+fla_znd_manage_zones_object_reset(struct flexalloc *fs, struct fla_pool const *pool_handle,
+                                  struct fla_object * obj)
+{
+  int err = 0;
+  uint64_t obj_slba = fla_object_slba(fs, obj, pool_handle);
+  struct fla_pool_entry *pool_entry = &fs->pools.entries[pool_handle->ndx];
+
+  for (uint32_t strp = 0; strp < pool_entry->strp_nobjs; strp++)
+  {
+
+    err = fla_xne_dev_znd_send_mgmt(fs->dev.dev, obj_slba + (fs->geo.nzsect * strp),
+                                    XNVME_SPEC_ZND_CMD_MGMT_SEND_RESET, false);
+    if (FLA_ERR(err, "fla_xne_dev_znd_send_mgmt_reset()"))
+      return err;
+  }
+  return err;
 }
 

--- a/src/flexalloc_znd.h
+++ b/src/flexalloc_znd.h
@@ -7,18 +7,13 @@
  */
 #ifndef __FLEXALLOC_ZND_H_
 #define __FLEXALLOC_ZND_H_
-#include <sys/queue.h>
-#include <stdint.h>
 #include "src/flexalloc.h"
 
+int
+fla_znd_manage_zones_object_finish(struct flexalloc *fs, struct fla_pool const *pool_handle,
+                                   struct fla_object *obj);
 
-void
-fla_znd_zone_full(struct flexalloc *fs, uint32_t zone);
-
-void
-fla_znd_manage_zones_cleanup(struct flexalloc *fs);
-
-void
-fla_znd_manage_zones(struct flexalloc *fs, uint32_t zone);
-
+int
+fla_znd_manage_zones_object_reset(struct flexalloc *fs, struct fla_pool const *pool_handle,
+                                  struct fla_object * obj);
 #endif // __FLEXALLOC_ZND_H

--- a/src/libflexalloc.h
+++ b/src/libflexalloc.h
@@ -165,6 +165,21 @@ fla_object_destroy(struct flexalloc *fs, struct fla_pool * pool,
                    struct fla_object * object);
 
 /**
+ *
+ * @brief Close a flexalloc object
+ *
+ * Runs logic signifying that the object will not be actively used.
+ * Might be a noop.
+ *
+ * @param fs flexalloc system handle
+ * @param pool_handle flexalloc pool handle associated with obj
+ * @param obj flexalloc object handle to close
+ * @return 0 on success. non zero otherwise.
+ */
+int
+fla_object_close(struct flexalloc *fs, struct fla_pool const *pool_handle, struct fla_object *obj);
+
+/**
  * @brief Allocate an aligned (to underlying file system) buffer
  *
  * @param fs flexalloc system handle
@@ -276,18 +291,6 @@ fla_fs_nzsect(struct flexalloc const * const fs);
 
 bool
 fla_fs_zns(struct flexalloc const *const fs);
-
-/**
- *
- * @brief Seal a flexalloc object
- *
- * @param fs flexalloc system handle
- * @param pool_handle flexalloc pool handle associated with obj
- * @param obj flexalloc object handle to seal
- * @return bool indicating object was successfully sealed
- */
-bool
-fla_object_seal(struct flexalloc *fs, struct fla_pool const *pool_handle, struct fla_object *obj);
 
 /**
  *

--- a/src/libflexalloc.h
+++ b/src/libflexalloc.h
@@ -165,10 +165,11 @@ fla_object_destroy(struct flexalloc *fs, struct fla_pool * pool,
                    struct fla_object * object);
 
 /**
- *
- * @brief Close a flexalloc object
+ * @brief Seal a flexalloc object
  *
  * Runs logic signifying that the object will not be actively used.
+ * Seal is different from close in contexts like ZNS where objects
+ * cannot just re-open.
  * Might be a noop.
  *
  * @param fs flexalloc system handle
@@ -177,7 +178,8 @@ fla_object_destroy(struct flexalloc *fs, struct fla_pool * pool,
  * @return 0 on success. non zero otherwise.
  */
 int
-fla_object_close(struct flexalloc *fs, struct fla_pool const *pool_handle, struct fla_object *obj);
+fla_object_seal(struct flexalloc *fs, struct fla_pool const *pool_handle,
+                struct fla_object *obj);
 
 /**
  * @brief Allocate an aligned (to underlying file system) buffer

--- a/tests/flexalloc_rt_strp_object_read_write.c
+++ b/tests/flexalloc_rt_strp_object_read_write.c
@@ -60,6 +60,10 @@ test_strp(struct test_vals test_vals)
   if (FLA_ERR(err, "fla_ut_dev_init()"))
     goto exit;
 
+  // Ignore test with real devices
+  if(test_vals.blk_num != dev.nblocks)
+    goto teardown_ut_dev;
+
   if (dev._is_zns)
   {
     // why *2? -> To run these tests we need at least one striped object. The

--- a/tests/flexalloc_ut_slab.c
+++ b/tests/flexalloc_ut_slab.c
@@ -69,16 +69,6 @@ test_slabs(struct test_vals * test_vals)
   if(dev._is_zns)
     goto exit;
 
-  /* Skip real devs
-   * The way we test slabs requires us to create slab sizes of 2 lbs
-   * For devices with lots of lbs, it takes too long. Skip it while
-   * we come up with a better way of doing things.
-   * if(test_vals->disk_min_lbs == 0)
-   *   test_vals->disk_min_lbs = dev.nblocks;
-   */
-  if(test_vals->disk_min_lbs != dev.nblocks)
-    goto exit;
-
   slab_error = malloc(sizeof(struct fla_slab_header));
   if (FLA_ERR(!slab_error, "malloc()"))
   {

--- a/tests/flexalloc_ut_slab.c
+++ b/tests/flexalloc_ut_slab.c
@@ -68,13 +68,13 @@ test_slabs(struct test_vals * test_vals)
    * rendering all our tests useless.
    */
   if(dev._is_zns)
-    goto exit;
+    goto teardown_ut_dev;
 
   slab_error = malloc(sizeof(struct fla_slab_header));
   if (FLA_ERR(!slab_error, "malloc()"))
   {
     err = -ENOMEM;
-    goto exit;
+    goto teardown_ut_dev;
   }
 
   slab_nlb = (uint32_t)(test_vals->min_disk_lbs * test_vals->slab_size_p);
@@ -167,6 +167,13 @@ close_fs:
 
 free_slab_error:
   free(slab_error);
+
+teardown_ut_dev:
+  ret = fla_ut_dev_teardown(&dev);
+  if (FLA_ERR(err, "fla_ut_dev_teardown()"))
+  {
+    err |= ret;
+  }
 
 exit:
   return err;

--- a/tests/flexalloc_ut_slab.c
+++ b/tests/flexalloc_ut_slab.c
@@ -8,33 +8,34 @@
 struct test_vals
 {
   uint32_t npools;
-  uint32_t slab_nlb;
-  uint32_t disk_min_lbs;
-  uint32_t obj_nlb;
+  uint32_t min_disk_lbs; // Will be overridden by real size on "real" HW.
+  float slab_size_p; // slab size in percent of disk size
+  float obj_size_p; // obje size in percent of slab size
 };
 
 static int test_slabs(struct test_vals * test_vals);
 static int test_check_slab_pointers(struct flexalloc * fs, const uint32_t expected_size);
 
-#define FLA_UT_SLAB_NUMBER_OF_TESTS 4
-
 int
 main(int argc, char ** argv)
 {
   int err = 0;
-  bool fla_test_set = is_globalenv_set("FLA_TEST_DEV");
-  struct test_vals test_vals [FLA_UT_SLAB_NUMBER_OF_TESTS] =
+
+  struct test_vals test_vals [] =
   {
-    {.npools = 2, .slab_nlb = 2, .disk_min_lbs = 9, .obj_nlb = 1 }
-    , {.npools = 2, .slab_nlb = 2, .disk_min_lbs = 21, .obj_nlb = 1 }
-    , {.npools = 2, .slab_nlb = 20, .disk_min_lbs = 50, .obj_nlb = 2 }
-    , {.npools = 2, .slab_nlb = 5, .disk_min_lbs = 18, .obj_nlb = 1 }
+    {.npools = 1, .min_disk_lbs = 100, .slab_size_p = 0.8, .obj_size_p = 0.8 }
+    , {.npools = 1, .min_disk_lbs = 100, .slab_size_p = 0.8, .obj_size_p = 0.2 }
+    , {.npools = 2, .min_disk_lbs = 100, .slab_size_p = 0.4, .obj_size_p = 0.8 }
+    , {.npools = 2, .min_disk_lbs = 100, .slab_size_p = 0.4, .obj_size_p = 0.2 }
+    , {.npools = 4, .min_disk_lbs = 100, .slab_size_p = 0.2, .obj_size_p = 0.8 }
+    , {.npools = 4, .min_disk_lbs = 100, .slab_size_p = 0.2, .obj_size_p = 0.2 }
+    , {.npools = 0, .min_disk_lbs = 0, .slab_size_p = 0, .obj_size_p = 0}
   };
 
-  for(int i = 0 ; i < FLA_UT_SLAB_NUMBER_OF_TESTS ; ++i)
+  for(int i = 0 ; true ; ++i)
   {
-    if(fla_test_set)
-      test_vals[i].disk_min_lbs = 0;
+    if (test_vals[i].npools == 0)
+      goto exit;
     err = test_slabs(&test_vals[i]);
     if(FLA_ERR(err, "test_slabs()"))
     {
@@ -53,14 +54,14 @@ test_slabs(struct test_vals * test_vals)
   struct fla_ut_dev dev;
   struct flexalloc *fs;
   struct fla_slab_header *slab_header, *slab_error;
-  uint64_t available_lb_for_slabs;
-  uint32_t expected_slabs;
+  uint32_t slab_nlb, obj_nlb, init_free_slabs;
 
-  err = fla_ut_dev_init(test_vals->disk_min_lbs, &dev);
+  err = fla_ut_dev_init(test_vals->min_disk_lbs, &dev);
   if (FLA_ERR(err, "fla_ut_dev_init()"))
   {
     goto exit;
   }
+  test_vals->min_disk_lbs = dev.nblocks;
 
   /* Skip for ZNS.
    * If we are testing ZNS, we will automatically modify slab size
@@ -76,36 +77,34 @@ test_slabs(struct test_vals * test_vals)
     goto exit;
   }
 
-  err = fla_ut_fs_create(test_vals->slab_nlb, test_vals->npools, &dev, &fs);
+  slab_nlb = (uint32_t)(test_vals->min_disk_lbs * test_vals->slab_size_p);
+  obj_nlb = (uint32_t)(slab_nlb * test_vals->obj_size_p);
+
+  err = fla_ut_fs_create(slab_nlb, test_vals->npools, &dev, &fs);
   if (FLA_ERR(err, "fla_ut_fs_create()"))
   {
     goto free_slab_error;
   }
 
-  FLA_ASSERTF(test_vals->disk_min_lbs > fla_geo_slabs_lb_off(&fs->geo),
+  init_free_slabs = *fs->slabs.fslab_num;
+
+  FLA_ASSERTF(test_vals->min_disk_lbs > fla_geo_slabs_lb_off(&fs->geo),
               "Slabs start after disk has ended (%"PRIu64" > %"PRIu64"",
-              test_vals->disk_min_lbs, fla_geo_slabs_lb_off(&fs->geo));
-  available_lb_for_slabs = test_vals->disk_min_lbs - fla_geo_slabs_lb_off(&fs->geo);
-  expected_slabs = available_lb_for_slabs / test_vals->slab_nlb;
+              test_vals->min_disk_lbs, fla_geo_slabs_lb_off(&fs->geo));
 
-  /* Test values in struct fla_slabs */
-  err |= FLA_ASSERTF(*fs->slabs.fslab_num == expected_slabs,
-                     "Unexpected number of free slabs (%d == %d)",
-                     *fs->slabs.fslab_num, expected_slabs);
+  /* we need at least one slab */
+  err |= FLA_ASSERTF(init_free_slabs >= 1, "Unexpected number of free slabs (%d >= 1)",
+                     init_free_slabs);
 
-  /*err |= FLA_ASSERTF(*fs->slabs.fslab_head == 0,
-                     "Unexpected head ID (%d == %d)", *fs->slabs.fslab_head, 0);*/
-
-  err |= FLA_ASSERTF(*fs->slabs.fslab_tail == expected_slabs - 1,
-                     "Unexpected tail ID (%d == %d)",
-                     *fs->slabs.fslab_tail, expected_slabs - 1);
+  err |= FLA_ASSERTF(*fs->slabs.fslab_head == 0,
+                     "Unexpected head ID (%d == %d)", *fs->slabs.fslab_head, 0);
 
   /* Acquire all the slabs and then release them all */
-  for(uint32_t slab_offset = 0 ; slab_offset < expected_slabs ; ++slab_offset)
+  for(uint32_t slab_offset = 0 ; slab_offset < init_free_slabs ; ++slab_offset)
   {
     slab_header = (void*)fs->slabs.headers + (slab_offset * sizeof(struct fla_slab_header));
 
-    err = fla_acquire_slab(fs, test_vals->obj_nlb, &slab_header);
+    err = fla_acquire_slab(fs, obj_nlb, &slab_header);
     if(FLA_ERR(err, "fla_acquire_slab()"))
     {
       goto close_fs;
@@ -120,16 +119,16 @@ test_slabs(struct test_vals * test_vals)
       goto close_fs;
     }
 
-    const uint32_t free_slabs = expected_slabs - (slab_offset + 1);
-    err = FLA_ASSERTF(*fs->slabs.fslab_num == free_slabs,
-                      "Unexpected number of free slabs (%d == %d)",
-                      *fs->slabs.fslab_num, free_slabs);
+    const uint32_t curr_free_slabs = init_free_slabs - (slab_offset + 1);
+    err = FLA_ASSERTF(*fs->slabs.fslab_num >= curr_free_slabs,
+                      "Unexpected number of free slabs (%d >= %d)",
+                      *fs->slabs.fslab_num, curr_free_slabs);
     if(FLA_ERR(err, "FLA_ASSERTF()"))
     {
       goto close_fs;
     }
 
-    err = test_check_slab_pointers(fs, free_slabs);
+    err = test_check_slab_pointers(fs, curr_free_slabs);
     if(FLA_ERR(err, "test_check_slab_pointers()"))
     {
       goto close_fs;
@@ -137,14 +136,14 @@ test_slabs(struct test_vals * test_vals)
   }
 
   /* If we acquire another slab, we should receive an error */
-  ret = fla_acquire_slab(fs, test_vals->obj_nlb, &slab_error);
+  ret = fla_acquire_slab(fs, obj_nlb, &slab_error);
   err = FLA_ASSERT(ret != 0, "Acquire of an empty free list did NOT fail");
   if(FLA_ERR(err, "FLA_ASSERT()"))
   {
     goto close_fs;
   }
 
-  for(uint32_t slab_offset = 0 ; slab_offset < expected_slabs ; ++slab_offset)
+  for(uint32_t slab_offset = 0 ; slab_offset < init_free_slabs ; ++slab_offset)
   {
     slab_header = (void*)fs->slabs.headers + (slab_offset * sizeof(struct fla_slab_header));
 
@@ -152,8 +151,8 @@ test_slabs(struct test_vals * test_vals)
     if(FLA_ERR(err, "fla_release_slab()"))
       goto close_fs;
 
-    err = FLA_ASSERTF(*fs->slabs.fslab_num == slab_offset + 1,
-                      "Unexpected number of free slabs (%d == %d)",
+    err = FLA_ASSERTF(*fs->slabs.fslab_num >= slab_offset + 1,
+                      "Unexpected number of free slabs (%d >= %d)",
                       *fs->slabs.fslab_num, slab_offset + 1);
     if(FLA_ERR(err, "FLA_ASSERTF()"))
       goto close_fs;
@@ -174,7 +173,7 @@ exit:
 }
 
 int
-test_check_slab_pointers(struct flexalloc * fs, const uint32_t expected_size)
+test_check_slab_pointers(struct flexalloc * fs, const uint32_t curr_free_slabs)
 {
   int err = 0;
   struct fla_slab_header * curr_slab;
@@ -182,7 +181,7 @@ test_check_slab_pointers(struct flexalloc * fs, const uint32_t expected_size)
 
   /* check next pointers */
   curr_slab_id = *fs->slabs.fslab_head;
-  for (uint32_t i = 0 ; i <= expected_size && curr_slab_id != INT32_MAX; ++i)
+  for (uint32_t i = 0 ; i <= curr_free_slabs && curr_slab_id != INT32_MAX; ++i)
   {
     curr_slab = fla_slab_header_ptr(curr_slab_id, fs);
     if((err = -FLA_ERR(!curr_slab, "fla_slab_header_ptr()")))
@@ -193,13 +192,13 @@ test_check_slab_pointers(struct flexalloc * fs, const uint32_t expected_size)
     size_from_head++;
   }
 
-  err = FLA_ASSERTF(size_from_head == expected_size,
+  err = FLA_ASSERTF(size_from_head >= curr_free_slabs,
                     "Unexpected size when starting from head (%d == %d)",
-                    size_from_head, expected_size);
+                    size_from_head, curr_free_slabs);
 
   /* check prev pointers */
   curr_slab_id = *fs->slabs.fslab_tail;
-  for (uint32_t i = 0; i <= expected_size && curr_slab_id != INT32_MAX; ++i)
+  for (uint32_t i = 0; i <= curr_free_slabs && curr_slab_id != INT32_MAX; ++i)
   {
     curr_slab = fla_slab_header_ptr(curr_slab_id, fs);
     if((err = -FLA_ERR(!curr_slab, "fla_slab_header_ptr()")))


### PR DESCRIPTION
Tests:
* Ignore "real" devices when running tests: In order to run tests with the FLA_TEST_DEV vars we need to ignore some tests so we do not get false negatives
* Generalize tests by using percentages: Originally the tests were designed to work with loopback devices and so the setup and checks were done with very specific values in mind. But when we use the FLA_TEST_DEV vars, we need to adjust the tests to expect any devices configuration.
The test changes fix issue#40, issue#39, issue#52

ZNS:
* ZNS: let device keep track of the active resources. We switch FLA from keeping track of what zones where open to just letting the drive handle everything and bubling up an error when it occurs.

Various Fixes
* Fix the situation where loopback devices were left open when run-tests was run. fixes issue#39
* Fix the situation where we lost count of the free objects in a slab with striped objects. Now we free them all
* Fix an off by one issue in freelist where we missed freeing one object in slabs.