### PR TITLE
freelist: Add generic search function

### DIFF
--- a/src/flexalloc_freelist.h
+++ b/src/flexalloc_freelist.h
@@ -3,6 +3,7 @@
 
 #include <stdint.h>
 #include <stddef.h>
+#include <stdarg.h>
 
 typedef uint32_t * freelist_t;
 
@@ -149,5 +150,25 @@ fla_flist_entry_free(freelist_t flist, uint32_t ndx);
 
 int
 fla_flist_entries_free(freelist_t flist, uint32_t ndx, unsigned int num);
+
+/**
+ * Search all the used element by executing a function.
+ *
+ *
+ * @param flist freelist handle
+ * @param flags modifies how the function is executed.
+ *        When FLA_FLIST_SEARCH_EXEC_FIRST is set returns on first find
+ * @param found is the number of times f returned 1
+ * @param f The function that will be executed. Must Return < 0
+ *        on error, must return 0 when an element was not "found",
+ *        must return 1 when an element was "found".
+ * @param ... These are the variadic arguments that will be
+ *        forwarded to the f function.
+ * @return <0 if there is an error. 0 otherwise.
+ */
+int
+fla_flist_search_wfunc(freelist_t flist, uint64_t flags, uint32_t *found,
+                       int(*f)(const uint32_t, va_list), ...);
+#define FLA_FLIST_SEARCH_EXEC_FIRST 1 << 0
 
 #endif // __FLEXALLOC_FREELIST_H_

--- a/src/flexalloc_mm.c
+++ b/src/flexalloc_mm.c
@@ -58,7 +58,7 @@ fla_dev_sanity_check(struct xnvme_dev const * dev, struct xnvme_dev const *md_de
 }
 
 void
-print_slab_sgmt(const struct flexalloc * fs, uint32_t from , uint32_t to)
+print_slab_sgmt(const struct flexalloc * fs, uint32_t from, uint32_t to)
 {
   struct fla_slab_header * slab;
 

--- a/tests/flexalloc_rt_strp_object_read_write.c
+++ b/tests/flexalloc_rt_strp_object_read_write.c
@@ -53,7 +53,8 @@ struct test_vals tests[] =
   },
 };
 
-bool should_write_fail(struct fla_ut_dev * dev, struct test_vals * test_vals)
+bool
+should_write_fail(struct fla_ut_dev * dev, struct test_vals * test_vals)
 {
   if(dev->_is_zns)
   {
@@ -80,7 +81,7 @@ test_strp(struct test_vals test_vals)
   pool_handle_name = "mypool";
 
   if(FLA_ERR(test_vals.xfer_nstrps < 1, "Test needs to transfer more than zero lbs"))
-      goto exit;
+    goto exit;
 
   test_vals.obj_nlb = test_vals.obj_nstrp * test_vals.strp_nlbs;
   test_vals.slab_nlb = test_vals.obj_nlb * test_vals.strp_nobj * 4;


### PR DESCRIPTION
We leverage the effective way we traverse our free list to execute a generic function for every non-free element. The intended way to introduce the new fla_flist_search_wfunc function is:

  int ret;
  uint32_t found;
  ret = fla_flist_search_wfunc(flist, type, &found, func)

Where "found" will have the amount of times the "func" function found something in the freelist. The function also accepts additional variadic arguments so it can pass all the necessary data to the func call.

Signed-off-by: Joel Granados <j.granados@samsung.com>