### PR TITLE
flan_md: Fix debug print by changing the data type to flan_oinfo

### DIFF
--- a/flan/flan_md.c
+++ b/flan/flan_md.c
@@ -1,4 +1,5 @@
 #include "flan_md.h"
+#include "flan.h"
 #include "flexalloc_util.h"
 #include "libflexalloc.h"
 #include "flexalloc_mm.h"
@@ -147,18 +148,11 @@ static int
 flan_md_print_root_obj_elem(const uint32_t ndx, va_list ag)
 {
   void * root_buf = va_arg(ag, void*);
+  struct flan_oinfo *tmp;
 
-  struct tmp_{
-    uint64_t size;
-    struct fla_object fla_oh[2];
-    char name[112];
-    int pool_type;
-  } *tmp ;
-
-  tmp = (((struct tmp_*)root_buf) + ndx);
+  tmp = (((struct flan_oinfo*)root_buf) + ndx);
   fprintf(stderr, "`-> Object (%s)\n", tmp->name);
-  fprintf(stderr, "    Size : (%"PRIu64"\n", tmp->size);
-  fprintf(stderr, "    Pool : (%d)\n", tmp->pool_type);
+  fprintf(stderr, "    Size : (%"PRIu64")\n", tmp->size);
   fprintf(stderr, "    ndx : (%"PRIu32")\n" , ndx);
 
   return FLA_FLIST_SEARCH_RET_FOUND_CONTINUE;


### PR DESCRIPTION
`flan_md_print_root_obj_elem` was reading the root object into memory and casting it to a tmp struct defined in the method. This struct no longer matched the `flan_oinfo` struct which was seemingly the one saved to disk. Therefore the first object was read fine, but the next few objects were reporting incredibly inaccurate data, such as having no name, incredibly large sizes etc. Essentially just what was in the unaligned piece of memory it read.

To fix the issue i import the `flan_oinfo` struct and cast to that. This fixes the issues, and ensures that it still reports correctly if any of the constants used to define that struct changes, such as the name length. There is some regression in that it no longer prints the pool type, since that is not data that we have access to.

There is one more addition: a closing parentheses after the size of the object, which seemed to be missing.